### PR TITLE
Require libopencv-dev on Debian systems

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -20,9 +20,7 @@ runs:
           libboost-system-dev \
           libbz2-dev \
           libexpat1-dev \
-          libopencv-core-dev \
-          libopencv-imgcodecs-dev \
-          libopencv-imgproc-dev \
+          libopencv-dev \
           libpotrace-dev \
           libpq-dev \
           libproj-dev \

--- a/README.md
+++ b/README.md
@@ -84,9 +84,8 @@ On a Debian or Ubuntu system, this can be done with:
 ```sh
 sudo apt-get install make cmake g++ libboost-dev libboost-system-dev \
   libboost-filesystem-dev libexpat1-dev zlib1g-dev libpotrace-dev \
-  libopencv-core-dev libopencv-imgcodecs-dev libopencv-imgproc-dev \
-  libbz2-dev libpq-dev libproj-dev lua5.3 liblua5.3-dev pandoc \
-  nlohmann-json3-dev pyosmium
+  libopencv-dev libbz2-dev libpq-dev libproj-dev lua5.3 liblua5.3-dev \
+  pandoc nlohmann-json3-dev pyosmium
 ```
 
 On a Fedora system, use


### PR DESCRIPTION
This package contains the CMake files needed to build osm2pgsql.

I was having build failures on a new server that I didn't have at home where it couldn't find the cmake file.

```
$ dpkg -S /usr/lib/x86_64-linux-gnu/cmake/opencv4/OpenCVConfig.cmake
libopencv-dev: /usr/lib/x86_64-linux-gnu/cmake/opencv4/OpenCVConfig.cmake
```

This showed it was part of libopencv-dev, which wasn't specified as required. The other opencv packages are dependencies of it.

It would be nice if the cmake files were part of a libopencv-core-dev or something so we didn't need to install all the libopencv-*-dev packages, but that's not how Debian packaged it.