### PR TITLE
Github action: Remove OpenCV lib from windows build

### DIFF
--- a/.github/actions/win-install/action.yml
+++ b/.github/actions/win-install/action.yml
@@ -16,7 +16,6 @@ runs:
           libpq:x64-windows \
           lua:x64-windows \
           nlohmann-json:x64-windows \
-          opencv:x64-windows \
           proj4:x64-windows \
           zlib:x64-windows
       shell: bash


### PR DESCRIPTION
It is only needed for building osm2pgsql-gen but that also needs potrace which is not installed, because it isn't available as vcpkg.