### PR TITLE
Github action: Disable build on macOS 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-11"
           - "macos-12" # latest
           - "macos-13"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Because it doesn't work any more. Github actions output shows this message:

Error: You are using macOS 11.
We (and Apple) do not provide support for this old version. It is expected behaviour that some formulae will fail to build in this old version. It is expected behaviour that Homebrew will be buggy and slow. Do not create any issues about this on Homebrew's GitHub repositories. Do not create any issues even if you think this message is unrelated. Any opened issues will be immediately closed without response. Do not ask for help from Homebrew or its maintainers on social media. You may ask for help in Homebrew's discussions but are unlikely to receive a response. Try to figure out the problem yourself and submit a fix as a pull request. We will review it but may or may not accept it.