### PR TITLE
Get rid of two boolean vars during comman line parsing

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -617,7 +617,6 @@ options_t parse_command_line(int argc, char *argv[])
             break;
         case 'S': // --style
             options.style = optarg;
-            options.style_set = true;
             break;
         case 'i': // --tablespace-index
             options.tblsmain_index = optarg;

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -646,7 +646,6 @@ options_t parse_command_line(int argc, char *argv[])
             break;
         case 'O': // --output
             options.output_backend = optarg;
-            options.output_backend_set = true;
             break;
         case 'x': // --extra-attributes
             options.extra_attributes = true;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -164,7 +164,6 @@ struct options_t
     bool pass_prompt = false;
 
     bool output_backend_set = false;
-    bool style_set = false;
 }; // struct options_t
 
 #endif // OSM2PGSQL_OPTIONS_HPP

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -92,7 +92,7 @@ struct options_t
     /// File name to output expired tiles list to
     std::string expire_tiles_filename{"dirty_tiles"};
 
-    std::string output_backend{"pgsql"};
+    std::string output_backend;
     std::string input_format; ///< input file format (default: autodetect)
 
     osmium::Box bbox;
@@ -162,8 +162,6 @@ struct options_t
     bool parallel_indexing = true;
     bool create = false;
     bool pass_prompt = false;
-
-    bool output_backend_set = false;
 }; // struct options_t
 
 #endif // OSM2PGSQL_OPTIONS_HPP

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -256,7 +256,7 @@ static void check_output(properties_t const &properties, options_t *options)
 {
     auto const output = properties.get_string("output", "pgsql");
 
-    if (!options->output_backend_set) {
+    if (options->output_backend.empty()) {
         options->output_backend = output;
         log_info("Using output '{}' (same as on import).", output);
         return;
@@ -334,8 +334,12 @@ static void check_for_nodes_table(options_t const &options)
     }
 }
 
-static void check_and_set_style(options_t *options)
+static void set_option_defaults(options_t *options)
 {
+    if (options->output_backend.empty()) {
+        options->output_backend = "pgsql";
+    }
+
     if (options->style.empty()) {
         if (options->output_backend == "flex" ||
             options->output_backend == "gazetteer") {
@@ -375,7 +379,7 @@ int main(int argc, char *argv[])
             if (properties.load()) {
                 check_and_update_properties(&properties, &options);
             } else {
-                check_and_set_style(&options);
+                set_option_defaults(&options);
                 check_for_nodes_table(options);
             }
 
@@ -393,7 +397,7 @@ int main(int argc, char *argv[])
                 }
             }
         } else {
-            check_and_set_style(&options);
+            set_option_defaults(&options);
             store_properties(&properties, options);
             auto const finfo = run(options);
             store_data_properties(&properties, finfo);

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -336,7 +336,7 @@ static void check_for_nodes_table(options_t const &options)
 
 static void check_and_set_style(options_t *options)
 {
-    if (!options->style_set) {
+    if (options->style.empty()) {
         if (options->output_backend == "flex" ||
             options->output_backend == "gazetteer") {
             throw std::runtime_error{"You have to set the config file "

--- a/tests/common-options.hpp
+++ b/tests/common-options.hpp
@@ -22,6 +22,7 @@ class opt_t
 public:
     opt_t()
     {
+        m_opt.output_backend = "pgsql";
         m_opt.prefix = "osm2pgsql_test";
         m_opt.style = OSM2PGSQLDATA_DIR "default.style";
         m_opt.num_procs = 1;

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -22,8 +22,9 @@ TEST_CASE("Projection setup")
 {
     char const* const style_file = OSM2PGSQLDATA_DIR "default.style";
 
-    std::vector<char const *> option_params = {"osm2pgsql", "-S", style_file,
-                                               "--number-processes", "1"};
+    std::vector<char const *> option_params = {"osm2pgsql", "--output=pgsql",
+                                               "-S", style_file,
+                                               "--number-processes=1"};
 
     std::string proj_name;
     char const *srid = "";


### PR DESCRIPTION
They were used to differentiate between empty and default value, but we can do that differently.