### PR TITLE
Github action: Disable build on macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os:
           - "macos-12" # latest
-          - "macos-13"
+#          - "macos-13" disabled, because it doesn't work due to some problem with Homebrew
     runs-on: ${{ matrix.os }}
 
     env:


### PR DESCRIPTION
Because it doesn't work due to some problem with Homebrew