### PR TITLE
Remove info that new middle db format is experimental from man page

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -208,8 +208,7 @@ Set the database format for the middle tables to FORMAT.
 Allowed formats are \f[B]legacy\f[R] and \f[B]new\f[R].
 The \f[B]legacy\f[R] format is the old format that will eventually be
 deprecated and removed but is currently still the default.
-The \f[B]new\f[R] format was introduced in version 1.9.0 and is still
-experimental.
+The \f[B]new\f[R] format was introduced in version 1.9.0.
 See the manual for details on these formats.
 (Only works with \f[B]--slim\f[R].
 In append mode osm2pgsql will automatically detect the database format,

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -181,8 +181,8 @@ mandatory for short options too.
 :   Set the database format for the middle tables to FORMAT. Allowed formats
     are **legacy** and **new**. The **legacy** format is the old format that
     will eventually be deprecated and removed but is currently still the
-    default. The **new** format was introduced in version 1.9.0 and is still
-    experimental. See the manual for details on these formats. (Only works
+    default. The **new** format was introduced in version 1.9.0.
+    See the manual for details on these formats. (Only works
     with **\--slim**. In append mode osm2pgsql will automatically detect the
     database format, so don't use this with **-a, \--append**.)
 


### PR DESCRIPTION
This should have been removed before version 1.10.0.