### PR TITLE
Disable synchronous commit on all connections

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -130,9 +130,6 @@ void db_copy_thread_t::thread_t::operator()()
     try {
         m_conn = std::make_unique<pg_conn_t>(m_connection_params, "copy");
 
-        // Let commits happen faster by delaying when they actually occur.
-        m_conn->exec("SET synchronous_commit = off");
-
         // Disable sequential scan on database tables in the copy threads.
         // The copy threads only do COPYs (which are unaffected by this
         // setting) and DELETEs which we know benefit from the index. For

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -247,7 +247,6 @@ void table_connection_t::connect(connection_params_t const &connection_params)
 
     m_db_connection =
         std::make_unique<pg_conn_t>(connection_params, "out.flex.table");
-    m_db_connection->exec("SET synchronous_commit = off");
 }
 
 static void enable_check_trigger(pg_conn_t const &db_connection,

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -75,6 +75,11 @@ pg_conn_t::pg_conn_t(connection_params_t const &connection_params,
     if (!get_logger().debug_enabled()) {
         exec("SET client_min_messages = WARNING");
     }
+
+    // Disable synchronous_commit on all connections. For some connections it
+    // might not matter, especially if they read only, but then it doesn't
+    // hurt either.
+    exec("SET synchronous_commit = off");
 }
 
 void pg_conn_t::close()

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -67,8 +67,6 @@ void table_t::sync() { m_copy.sync(); }
 void table_t::connect()
 {
     m_sql_conn = std::make_unique<pg_conn_t>(m_connection_params, "out.pgsql");
-    //let commits happen faster by delaying when they actually occur
-    m_sql_conn->exec("SET synchronous_commit = off");
 }
 
 void table_t::start(connection_params_t const &connection_params,


### PR DESCRIPTION
This simplifies the code, because we don't have to decide whether to set this or not on each connection. And it doesn't matter much when setting this for read-only connections which don't need this.

Setting synchronous_commit = off speeds up writing to the database, because commis are not delayed until the WAL is written to disk. It can not lead to corruption of the database.

https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT