### PR TITLE
Add more checks of command line options

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -225,8 +225,11 @@ static void check_options(options_t *options)
     if (!options->slim && !options->flat_node_file.empty()) {
         log_warn("Ignoring --flat-nodes/-F setting in non-slim mode");
     }
+}
 
-    // zoom level 31 is the technical limit because we use 32-bit integers for the x and y index of a tile ID
+static void check_options_expire(options_t *options) {
+    // Zoom level 31 is the technical limit because we use 32-bit integers for
+    // the x and y index of a tile ID.
     if (options->expire_tiles_zoom_min > 31) {
         options->expire_tiles_zoom_min = 31;
         log_warn("Minimum zoom level for tile expiry is too "
@@ -735,6 +738,8 @@ options_t parse_command_line(int argc, char *argv[])
     if (!options.projection) {
         options.projection = reprojection::create_projection(PROJ_SPHERE_MERC);
     }
+
+    check_options_expire(&options);
 
     check_options(&options);
 


### PR DESCRIPTION
These three commits add various checks for combinations of command line options which make no sense and so should not be used. For most of these warnings about ignored options are printed (which we can turn into hard fails in a later version of osm2pgsql). For the projection setting options (--latlong, -l, --merc, -m, --proj, and -E) an error is produced, because results are undefined if they are used together.

See individual commits.

Fixes #142