### PR TITLE
Significantly reduce number of db connection in flex output

### DIFF
--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -41,7 +41,8 @@ static flex_table_t &create_flex_table(lua_State *lua_state,
         throw fmt_error("Table with name '{}' already exists.", table_name);
     }
 
-    auto &new_table = tables->emplace_back(default_schema, table_name);
+    auto &new_table =
+        tables->emplace_back(default_schema, table_name, tables->size());
 
     lua_pop(lua_state, 1); // "name"
 

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -59,8 +59,8 @@ public:
         permanent
     };
 
-    flex_table_t(std::string schema, std::string name)
-    : m_schema(std::move(schema)), m_name(std::move(name))
+    flex_table_t(std::string schema, std::string name, std::size_t num)
+    : m_schema(std::move(schema)), m_name(std::move(name)), m_table_num(num)
     {
     }
 
@@ -197,6 +197,8 @@ public:
 
     bool has_columns_with_expire() const noexcept;
 
+    std::size_t num() const noexcept { return m_table_num; }
+
 private:
     /// The schema this table is in
     std::string m_schema;
@@ -229,6 +231,9 @@ private:
      * geometry column.
      */
     std::size_t m_geom_column = std::numeric_limits<std::size_t>::max();
+
+    /// Unique number for each table.
+    std::size_t m_table_num;
 
     /**
      * Type of id stored in this table.

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -260,31 +260,28 @@ public:
       m_target(std::make_shared<db_target_descr_t>(
           table->schema(), table->name(), table->id_column_names(),
           table->build_sql_column_list())),
-      m_copy_mgr(copy_thread), m_db_connection(nullptr)
+      m_copy_mgr(copy_thread)
     {
     }
 
-    void connect(connection_params_t const &connection_params);
+    void start(pg_conn_t const &db_connection, bool append);
 
-    void start(bool append);
-
-    void stop(bool updateable, bool append);
+    void stop(pg_conn_t const &db_connection, bool updateable, bool append);
 
     flex_table_t const &table() const noexcept { return *m_table; }
 
-    void teardown() { m_db_connection.reset(); }
+    void prepare(pg_conn_t const &db_connection);
 
-    void prepare();
+    void analyze(pg_conn_t const &db_connection);
 
-    void analyze();
-
-    void create_id_index();
+    void create_id_index(pg_conn_t const &db_connection);
 
     /**
      * Get all geometries that have at least one expire config defined
      * from the database and return the result set.
      */
-    pg_result_t get_geoms_by_id(osmium::item_type type, osmid_t id) const;
+    pg_result_t get_geoms_by_id(pg_conn_t const &db_connection,
+                                osmium::item_type type, osmid_t id) const;
 
     void flush() { m_copy_mgr.flush(); }
 
@@ -331,9 +328,6 @@ private:
      * to the database server.
      */
     db_copy_mgr_t<db_deleter_by_type_and_id_t> m_copy_mgr;
-
-    /// The connection to the database server.
-    std::unique_ptr<pg_conn_t> m_db_connection;
 
     task_result_t m_task_result;
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -290,8 +290,8 @@ private:
 
     std::vector<table_connection_t> m_table_connections;
 
-    /// The connections to the database server for each table.
-    std::vector<pg_conn_t> m_db_connections;
+    /// The connection to the database server.
+    pg_conn_t m_db_connection;
 
     // This is shared between all clones of the output and must only be
     // accessed while protected using the lua_mutex.

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -224,7 +224,9 @@ private:
     void add_row(table_connection_t *table_connection, OBJECT const &object);
 
     void delete_from_table(table_connection_t *table_connection,
+                           pg_conn_t const &db_connection,
                            osmium::item_type type, osmid_t osm_id);
+
     void delete_from_tables(osmium::item_type type, osmid_t osm_id);
 
     lua_State *lua_state() noexcept { return m_lua_state.get(); }
@@ -287,6 +289,9 @@ private:
         std::make_shared<std::vector<expire_output_t>>();
 
     std::vector<table_connection_t> m_table_connections;
+
+    /// The connections to the database server for each table.
+    std::vector<pg_conn_t> m_db_connections;
 
     // This is shared between all clones of the output and must only be
     // accessed while protected using the lua_mutex.

--- a/tests/test-flex-indexes.cpp
+++ b/tests/test-flex-indexes.cpp
@@ -48,7 +48,7 @@ TEST_CASE("check index with single column", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("geom", "geometry", "");
 
     REQUIRE(table.indexes().empty());
@@ -71,7 +71,7 @@ TEST_CASE("check index with multiple columns", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("a", "int", "");
     table.add_column("b", "int", "");
 
@@ -93,7 +93,7 @@ TEST_CASE("check unique index", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
 
     REQUIRE(tf.run_lua(
@@ -115,7 +115,7 @@ TEST_CASE("check index with tablespace from table", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.set_index_tablespace("foo");
     table.add_column("col", "int", "");
 
@@ -137,7 +137,7 @@ TEST_CASE("check index with tablespace", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
 
     REQUIRE(tf.run_lua("return { method = 'btree', column = 'col', tablespace "
@@ -159,7 +159,7 @@ TEST_CASE("check index with expression and where clause", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "text", "");
 
     REQUIRE(tf.run_lua("return { method = 'btree', expression = 'lower(col)',"
@@ -181,7 +181,7 @@ TEST_CASE("check index with include", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -204,7 +204,7 @@ TEST_CASE("check index with include as array", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -227,7 +227,7 @@ TEST_CASE("check index with empty include array", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -250,7 +250,7 @@ TEST_CASE("check multiple indexes", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("a", "int", "");
     table.add_column("b", "int", "");
 
@@ -273,7 +273,7 @@ TEST_CASE("check various broken index configs", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"public", "test_table"};
+    flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "text", "");
 
     SECTION("empty index description") { REQUIRE(tf.run_lua("return {}")); }


### PR DESCRIPTION
Flex outputs uses a lot of connections, basically O(number of threads * number of tables). They are mostly idle but need resources on the server. And the PostgreSQL default max number of connections is often not large enough.

With these changes the number of connections is much smaller, connections are not open for such long a time.

* Use the same connection for all tables when creating the tables and various other setup tasks
* We have one extra connection for the COPYs
* Clustering, index creation is done in one connection per thread in the thread pool

There is probably more we can do here, closing some connections earlier or so. But this is a big step solving most of the problem.