### PR TITLE
Mark command line option -i, --tablespace-index as deprecated

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -115,6 +115,9 @@ Example: \f[B]--bbox\f[R] \f[B]-0.5,51.25,0.5,51.75\f[R]
 -i, --tablespace-index=TABLESPC
 Store all indexes in the PostgreSQL tablespace \f[V]TABLESPC\f[R].
 This option also affects the tables created by the pgsql output.
+This option is deprecated.
+Use the --tablespace-slim-index and/or --tablespace-main-index options
+instead.
 .TP
 --tablespace-slim-data=TABLESPC
 Store the slim mode tables in the given tablespace.
@@ -245,6 +248,9 @@ no default.)
 -i, --tablespace-index=TABLESPC
 Store all indexes in the PostgreSQL tablespace \f[V]TABLESPC\f[R].
 This option also affects the middle tables.
+This option is deprecated.
+Use the --tablespace-slim-index and/or --tablespace-main-index options
+instead.
 .TP
 --tablespace-main-data=TABLESPC
 Store the data tables in the PostgreSQL tablespace \f[V]TABLESPC\f[R].

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -111,7 +111,9 @@ mandatory for short options too.
 
 -i, \--tablespace-index=TABLESPC
 :   Store all indexes in the PostgreSQL tablespace `TABLESPC`. This option
-    also affects the tables created by the pgsql output.
+    also affects the tables created by the pgsql output. This option is
+    deprecated. Use the \--tablespace-slim-index and/or \--tablespace-main-index
+    options instead.
 
 \--tablespace-slim-data=TABLESPC
 :   Store the slim mode tables in the given tablespace.
@@ -211,7 +213,8 @@ mandatory for short options too.
 
 -i, \--tablespace-index=TABLESPC
 :   Store all indexes in the PostgreSQL tablespace `TABLESPC`. This option
-    also affects the middle tables.
+    also affects the middle tables. This option is deprecated. Use the
+    \--tablespace-slim-index and/or \--tablespace-main-index options instead.
 
 \--tablespace-main-data=TABLESPC
 :   Store the data tables in the PostgreSQL tablespace `TABLESPC`.

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -724,6 +724,9 @@ options_t parse_command_line(int argc, char *argv[])
     }
 
     if (!tablespace_index.empty()) {
+        log_warn(
+            "The option -i, --tablespace-index is deprecated. Use "
+            "--tablespace-slim-index and/or --tablespace-main-index instead.");
         if (options.tblsmain_index.empty()) {
             options.tblsmain_index = tablespace_index;
         }


### PR DESCRIPTION
Fixes #2133