### PR TITLE
Mark --with-forward-dependencies as deprecated in man page

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -208,10 +208,9 @@ See documentation for details.
 .TP
 --middle-database-format=FORMAT
 Set the database format for the middle tables to FORMAT.
-Allowed formats are \f[B]legacy\f[R] and \f[B]new\f[R].
-The \f[B]legacy\f[R] format is the old format that will eventually be
-deprecated and removed but is currently still the default.
-The \f[B]new\f[R] format was introduced in version 1.9.0.
+Allowed formats are \f[B]new\f[R] (default) and \f[B]legacy\f[R] .
+The \f[B]legacy\f[R] format is deprecated and will be removed in version
+2.0.0.
 See the manual for details on these formats.
 (Only works with \f[B]--slim\f[R].
 In append mode osm2pgsql will automatically detect the database format,
@@ -351,6 +350,7 @@ Specifies the number of parallel threads used for certain operations.
 --with-forward-dependencies=BOOL
 Propagate changes from nodes to ways and node/way members to relations
 (Default: \f[V]true\f[R]).
+This option is deprecated.
 .SH SEE ALSO
 .IP \[bu] 2
 osm2pgsql website (https://osm2pgsql.org)

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -309,7 +309,7 @@ mandatory for short options too.
 
 \--with-forward-dependencies=BOOL
 :   Propagate changes from nodes to ways and node/way members to relations
-    (Default: `true`).
+    (Default: `true`). This option is deprecated.
 
 # SEE ALSO
 


### PR DESCRIPTION
The option was deprecated before, but I neglected to update the man page.