### PR TITLE
Move analyze() and prepare() from table_connection_t to flex_table_t

### DIFF
--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -199,6 +199,10 @@ public:
 
     std::size_t num() const noexcept { return m_table_num; }
 
+    void prepare(pg_conn_t const &db_connection) const;
+
+    void analyze(pg_conn_t const &db_connection) const;
+
 private:
     /// The schema this table is in
     std::string m_schema;
@@ -269,10 +273,6 @@ public:
     void stop(pg_conn_t const &db_connection, bool updateable, bool append);
 
     flex_table_t const &table() const noexcept { return *m_table; }
-
-    void prepare(pg_conn_t const &db_connection);
-
-    void analyze(pg_conn_t const &db_connection);
 
     void create_id_index(pg_conn_t const &db_connection);
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1266,8 +1266,8 @@ output_flex_t::output_flex_t(output_flex_t const *other,
   m_select_relation_members(other->m_select_relation_members)
 {
     for (auto &table : *m_tables) {
-        auto &tc = m_table_connections.emplace_back(&table, m_copy_thread);
-        tc.prepare(m_db_connection);
+        table.prepare(m_db_connection);
+        m_table_connections.emplace_back(&table, m_copy_thread);
     }
 
     for (auto &expire_output : *m_expire_outputs) {
@@ -1514,7 +1514,7 @@ void output_flex_t::reprocess_marked()
         for (auto &table : m_table_connections) {
             if (table.table().matches_type(osmium::item_type::way) &&
                 table.table().has_id_column()) {
-                table.analyze(m_db_connection);
+                table.table().analyze(m_db_connection);
                 table.create_id_index(m_db_connection);
             }
         }


### PR DESCRIPTION
They don't need anything from table_connection_t.