### PR TITLE
Sync output earlier for better objects/s numbers

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -153,6 +153,8 @@ void osmdata_t::after_relations()
     if (m_append) {
         m_dependency_manager->after_relations();
     }
+
+    m_output->sync();
 }
 
 void osmdata_t::start() const
@@ -406,8 +408,6 @@ void osmdata_t::postprocess_database() const
 
 void osmdata_t::stop() const
 {
-    m_output->sync();
-
     if (m_append && m_with_forward_dependencies) {
         process_dependents();
     }


### PR DESCRIPTION
Sync in after_relations() instead of in stop(). This makes the numbers of objects per second processed a bit more accurate.