### PR TITLE
Refactor idlist

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(osm2pgsql_lib PRIVATE
   geom-from-osm.cpp
   geom-functions.cpp
   geom-pole-of-inaccessibility.cpp
+  idlist.cpp
   input.cpp
   logging.cpp
   middle.cpp

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -15,17 +15,17 @@
 
 void full_dependency_manager_t::node_changed(osmid_t id)
 {
-    m_changed_nodes.set(id);
+    m_changed_nodes.push_back(id);
 }
 
 void full_dependency_manager_t::way_changed(osmid_t id)
 {
-    m_changed_ways.set(id);
+    m_changed_ways.push_back(id);
 }
 
 void full_dependency_manager_t::relation_changed(osmid_t id)
 {
-    m_changed_relations.set(id);
+    m_changed_relations.push_back(id);
 }
 
 void full_dependency_manager_t::after_nodes()
@@ -39,15 +39,13 @@ void full_dependency_manager_t::after_nodes()
     m_changed_nodes.clear();
 }
 
-static osmium::index::IdSetSmall<osmid_t>
-set_diff(osmium::index::IdSetSmall<osmid_t> const &set,
-         osmium::index::IdSetSmall<osmid_t> const &to_be_removed)
+static idlist_t set_diff(idlist_t const &set, idlist_t const &to_be_removed)
 {
-    osmium::index::IdSetSmall<osmid_t> new_set;
+    idlist_t new_set;
 
     for (auto const id : set) {
         if (!to_be_removed.get_binary_search(id)) {
-            new_set.set(id);
+            new_set.push_back(id);
         }
     }
 
@@ -92,7 +90,7 @@ void full_dependency_manager_t::after_relations()
 }
 
 void full_dependency_manager_t::mark_parent_relations_as_pending(
-    osmium::index::IdSetSmall<osmid_t> const &way_ids)
+    idlist_t const &way_ids)
 {
     assert(m_rels_pending_tracker.empty());
     m_object_store->get_way_parents(way_ids, &m_rels_pending_tracker);
@@ -103,8 +101,7 @@ bool full_dependency_manager_t::has_pending() const noexcept
     return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();
 }
 
-idlist_t
-full_dependency_manager_t::get_ids(osmium::index::IdSetSmall<osmid_t> *tracker)
+idlist_t full_dependency_manager_t::get_ids(idlist_t *tracker)
 {
     tracker->sort_unique();
 

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -39,27 +39,13 @@ void full_dependency_manager_t::after_nodes()
     m_changed_nodes.clear();
 }
 
-static idlist_t set_diff(idlist_t const &set, idlist_t const &to_be_removed)
-{
-    idlist_t new_set;
-
-    for (auto const id : set) {
-        if (!to_be_removed.get_binary_search(id)) {
-            new_set.push_back(id);
-        }
-    }
-
-    return new_set;
-}
-
 void full_dependency_manager_t::after_ways()
 {
     if (!m_changed_ways.empty()) {
         if (!m_ways_pending_tracker.empty()) {
             // Remove ids from changed ways in the input data from
             // m_ways_pending_tracker, because they have already been processed.
-            m_ways_pending_tracker =
-                set_diff(m_ways_pending_tracker, m_changed_ways);
+            m_ways_pending_tracker.remove_ids_if_in(m_changed_ways);
 
             // Add the list of pending way ids to the list of changed ways,
             // because we need the parents for them, too.
@@ -83,8 +69,7 @@ void full_dependency_manager_t::after_relations()
 {
     // Remove ids from changed relations in the input data from
     // m_rels_pending_tracker, because they have already been processed.
-    m_rels_pending_tracker =
-        set_diff(m_rels_pending_tracker, m_changed_relations);
+    m_rels_pending_tracker.remove_ids_if_in(m_changed_relations);
 
     m_changed_relations.clear();
 }

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -100,17 +100,3 @@ bool full_dependency_manager_t::has_pending() const noexcept
 {
     return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();
 }
-
-idlist_t full_dependency_manager_t::get_ids(idlist_t *tracker)
-{
-    tracker->sort_unique();
-
-    idlist_t list;
-    list.reserve(tracker->size());
-
-    std::copy(tracker->cbegin(), tracker->cend(), std::back_inserter(list));
-
-    tracker->clear();
-
-    return list;
-}

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -10,6 +10,7 @@
  * For a full list of authors see the git log.
  */
 
+#include "idlist.hpp"
 #include "osmtypes.hpp"
 
 #include <osmium/index/id_set.hpp>

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -115,17 +115,23 @@ public:
 
     idlist_t get_pending_way_ids() override
     {
-        return get_ids(&m_ways_pending_tracker);
+        idlist_t list;
+        using std::swap;
+        swap(list, m_ways_pending_tracker);
+        list.sort_unique();
+        return list;
     }
 
     idlist_t get_pending_relation_ids() override
     {
-        return get_ids(&m_rels_pending_tracker);
+        idlist_t list;
+        using std::swap;
+        swap(list, m_rels_pending_tracker);
+        list.sort_unique();
+        return list;
     }
 
 private:
-    static idlist_t get_ids(idlist_t *tracker);
-
     std::shared_ptr<middle_t> m_object_store;
 
     /**

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -13,8 +13,6 @@
 #include "idlist.hpp"
 #include "osmtypes.hpp"
 
-#include <osmium/index/id_set.hpp>
-
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -59,8 +57,7 @@ public:
     virtual void after_ways() {}
     virtual void after_relations() {}
 
-    virtual void mark_parent_relations_as_pending(
-        osmium::index::IdSetSmall<osmid_t> const & /*way_ids*/)
+    virtual void mark_parent_relations_as_pending(idlist_t const & /*way_ids*/)
     {
     }
 
@@ -112,8 +109,7 @@ public:
     void after_ways() override;
     void after_relations() override;
 
-    void mark_parent_relations_as_pending(
-        osmium::index::IdSetSmall<osmid_t> const &ids) override;
+    void mark_parent_relations_as_pending(idlist_t const &ids) override;
 
     bool has_pending() const noexcept override;
 
@@ -128,7 +124,7 @@ public:
     }
 
 private:
-    static idlist_t get_ids(osmium::index::IdSetSmall<osmid_t> *tracker);
+    static idlist_t get_ids(idlist_t *tracker);
 
     std::shared_ptr<middle_t> m_object_store;
 
@@ -140,7 +136,7 @@ private:
      * the change file, too, and so we don't have to find out which ones they
      * are.
      */
-    osmium::index::IdSetSmall<osmid_t> m_changed_nodes;
+    idlist_t m_changed_nodes;
 
     /**
      * In append mode all new and changed ways will be added to this. After
@@ -149,17 +145,17 @@ private:
      * relations that referenced deleted ways must be in the change file, too,
      * and so we don't have to find out which ones they are.
      */
-    osmium::index::IdSetSmall<osmid_t> m_changed_ways;
+    idlist_t m_changed_ways;
 
     /**
      * In append mode all new and changed relations will be added to this.
      * This is then used to remove already processed relations from the
      * pending list.
      */
-    osmium::index::IdSetSmall<osmid_t> m_changed_relations;
+    idlist_t m_changed_relations;
 
-    osmium::index::IdSetSmall<osmid_t> m_ways_pending_tracker;
-    osmium::index::IdSetSmall<osmid_t> m_rels_pending_tracker;
+    idlist_t m_ways_pending_tracker;
+    idlist_t m_rels_pending_tracker;
 };
 
 #endif // OSM2PGSQL_DEPENDENCY_MANAGER_HPP

--- a/src/idlist.cpp
+++ b/src/idlist.cpp
@@ -20,7 +20,7 @@ void idlist_t::sort_unique()
     m_list.erase(last, m_list.end());
 }
 
-void idlist_t::merge_sorted(const idlist_t &other)
+void idlist_t::merge_sorted(idlist_t const &other)
 {
     std::vector<osmid_t> new_list;
 

--- a/src/idlist.cpp
+++ b/src/idlist.cpp
@@ -31,3 +31,15 @@ void idlist_t::merge_sorted(idlist_t const &other)
     using std::swap;
     swap(new_list, m_list);
 }
+
+void idlist_t::remove_ids_if_in(idlist_t const &other)
+{
+    std::vector<osmid_t> new_list;
+
+    new_list.reserve(m_list.size());
+    std::set_difference(m_list.cbegin(), m_list.cend(), other.m_list.cbegin(),
+                        other.m_list.cend(), std::back_inserter(new_list));
+
+    using std::swap;
+    swap(new_list, m_list);
+}

--- a/src/idlist.cpp
+++ b/src/idlist.cpp
@@ -10,8 +10,17 @@
 #include "idlist.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <utility>
+
+osmid_t idlist_t::pop_id()
+{
+    assert(!m_list.empty());
+    auto const id = m_list.back();
+    m_list.pop_back();
+    return id;
+}
 
 void idlist_t::sort_unique()
 {

--- a/src/idlist.cpp
+++ b/src/idlist.cpp
@@ -1,0 +1,33 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "idlist.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+
+void idlist_t::sort_unique()
+{
+    std::sort(m_list.begin(), m_list.end());
+    const auto last = std::unique(m_list.begin(), m_list.end());
+    m_list.erase(last, m_list.end());
+}
+
+void idlist_t::merge_sorted(const idlist_t &other)
+{
+    std::vector<osmid_t> new_list;
+
+    new_list.reserve(m_list.size() + other.m_list.size());
+    std::set_union(m_list.cbegin(), m_list.cend(), other.m_list.cbegin(),
+                   other.m_list.cend(), std::back_inserter(new_list));
+
+    using std::swap;
+    swap(new_list, m_list);
+}

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -51,11 +51,6 @@ public:
 
     osmid_t operator[](std::size_t n) const noexcept { return m_list[n]; }
 
-    bool get_binary_search(osmid_t id) const noexcept
-    {
-        return std::binary_search(m_list.cbegin(), m_list.cend(), id);
-    }
-
     void clear() { m_list.clear(); }
 
     void push_back(osmid_t id) { m_list.push_back(id); }

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -77,6 +77,12 @@ public:
 
     void merge_sorted(idlist_t const &other);
 
+    /**
+     * Remove all ids in this list that are also in the other list. Both
+     * lists must be sorted.
+     */
+    void remove_ids_if_in(idlist_t const &other);
+
 private:
     std::vector<osmid_t> m_list;
 

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -27,8 +27,15 @@ public:
     using value_type = osmid_t;
 
     idlist_t() = default;
+    ~idlist_t() noexcept = default;
 
     idlist_t(std::initializer_list<osmid_t> ids) : m_list(ids) {}
+
+    idlist_t(idlist_t const &) = delete;
+    idlist_t &operator=(idlist_t const &) = delete;
+
+    idlist_t(idlist_t &&) = default;
+    idlist_t &operator=(idlist_t &&) = default;
 
     bool empty() const noexcept { return m_list.empty(); }
 

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -18,17 +18,55 @@
 
 #include "osmtypes.hpp"
 
+#include <cassert>
 #include <vector>
 
-struct idlist_t : public std::vector<osmid_t>
+class idlist_t
 {
-    // Get all constructors from std::vector
-    using vector<osmid_t>::vector;
+public:
+    using value_type = osmid_t;
 
-    // Even though we got all constructors from std::vector we need this on
-    // some compilers/libraries for some reason.
     idlist_t() = default;
 
-};
+    idlist_t(std::initializer_list<osmid_t> ids) : m_list(ids) {}
+
+    bool empty() const noexcept { return m_list.empty(); }
+
+    std::size_t size() const noexcept { return m_list.size(); }
+
+    auto begin() const noexcept { return m_list.begin(); }
+
+    auto end() const noexcept { return m_list.end(); }
+
+    osmid_t operator[](std::size_t n) const noexcept { return m_list[n]; }
+
+    void clear() { m_list.clear(); }
+
+    void push_back(osmid_t id) { m_list.push_back(id); }
+
+    void reserve(std::size_t size) { m_list.reserve(size); }
+
+    osmid_t pop_id()
+    {
+        assert(!m_list.empty());
+        auto const id = m_list.back();
+        m_list.pop_back();
+        return id;
+    }
+
+    friend bool operator==(idlist_t const &lhs, idlist_t const &rhs) noexcept
+    {
+        return lhs.m_list == rhs.m_list;
+    }
+
+    friend bool operator!=(idlist_t const &lhs, idlist_t const &rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    std::vector<osmid_t> m_list;
+
+}; // class idlist_t
 
 #endif // OSM2PGSQL_IDLIST_HPP

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -75,7 +75,7 @@ public:
 
     void sort_unique();
 
-    void merge_sorted(const idlist_t &other);
+    void merge_sorted(idlist_t const &other);
 
 private:
     std::vector<osmid_t> m_list;

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -1,0 +1,34 @@
+#ifndef OSM2PGSQL_IDLIST_HPP
+#define OSM2PGSQL_IDLIST_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+/**
+ * \file
+ *
+ * This file contains the definition of the idlist_t class.
+ */
+
+#include "osmtypes.hpp"
+
+#include <vector>
+
+struct idlist_t : public std::vector<osmid_t>
+{
+    // Get all constructors from std::vector
+    using vector<osmid_t>::vector;
+
+    // Even though we got all constructors from std::vector we need this on
+    // some compilers/libraries for some reason.
+    idlist_t() = default;
+
+};
+
+#endif // OSM2PGSQL_IDLIST_HPP

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -38,7 +38,16 @@ public:
 
     auto end() const noexcept { return m_list.end(); }
 
+    auto cbegin() const noexcept { return m_list.cbegin(); }
+
+    auto cend() const noexcept { return m_list.cend(); }
+
     osmid_t operator[](std::size_t n) const noexcept { return m_list[n]; }
+
+    bool get_binary_search(osmid_t id) const noexcept
+    {
+        return std::binary_search(m_list.cbegin(), m_list.cend(), id);
+    }
 
     void clear() { m_list.clear(); }
 
@@ -63,6 +72,10 @@ public:
     {
         return !(lhs == rhs);
     }
+
+    void sort_unique();
+
+    void merge_sorted(const idlist_t &other);
 
 private:
     std::vector<osmid_t> m_list;

--- a/src/idlist.hpp
+++ b/src/idlist.hpp
@@ -18,9 +18,14 @@
 
 #include "osmtypes.hpp"
 
-#include <cassert>
 #include <vector>
 
+/**
+ * A list of OSM object ids. Internally this is a vector of ids.
+ *
+ * Some operations are only allowed when the list of ids is sorted and
+ * without duplicates. Call sort_unique() to achieve this.
+ */
 class idlist_t
 {
 public:
@@ -51,20 +56,20 @@ public:
 
     osmid_t operator[](std::size_t n) const noexcept { return m_list[n]; }
 
-    void clear() { m_list.clear(); }
+    void clear() noexcept { m_list.clear(); }
 
     void push_back(osmid_t id) { m_list.push_back(id); }
 
     void reserve(std::size_t size) { m_list.reserve(size); }
 
-    osmid_t pop_id()
-    {
-        assert(!m_list.empty());
-        auto const id = m_list.back();
-        m_list.pop_back();
-        return id;
-    }
+    /**
+     * Remove id at the end of the list and return it.
+     *
+     * \pre \code !m_list.empty()) \endcode
+     */
+    osmid_t pop_id();
 
+    /// List are equal if they contain the same ids in the same order.
     friend bool operator==(idlist_t const &lhs, idlist_t const &rhs) noexcept
     {
         return lhs.m_list == rhs.m_list;
@@ -75,13 +80,22 @@ public:
         return !(lhs == rhs);
     }
 
+    /**
+     * Sort this list and remove duplicates.
+     */
     void sort_unique();
 
+    /**
+     * Merge other list into this one.
+     *
+     * \pre Both lists must be sorted and without duplicates.
+     */
     void merge_sorted(idlist_t const &other);
 
     /**
-     * Remove all ids in this list that are also in the other list. Both
-     * lists must be sorted.
+     * Remove all ids in this list that are also in the other list.
+     *
+     * \pre Both lists must be sorted and without duplicates.
      */
     void remove_ids_if_in(idlist_t const &other);
 

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -33,6 +33,7 @@
 #include <nlohmann/json.hpp>
 
 #include "format.hpp"
+#include "idlist.hpp"
 #include "json-writer.hpp"
 #include "logging.hpp"
 #include "middle-pgsql.hpp"

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -24,6 +24,7 @@
 #include <osmium/index/nwr_array.hpp>
 
 #include "db-copy-mgr.hpp"
+#include "idlist.hpp"
 #include "middle.hpp"
 #include "pgsql.hpp"
 
@@ -117,14 +118,11 @@ struct middle_pgsql_t : public middle_t
     void after_ways() override;
     void after_relations() override;
 
-    void get_node_parents(
-        osmium::index::IdSetSmall<osmid_t> const &changed_nodes,
-        osmium::index::IdSetSmall<osmid_t> *parent_ways,
-        osmium::index::IdSetSmall<osmid_t> *parent_relations) const override;
+    void get_node_parents(idlist_t const &changed_nodes, idlist_t *parent_ways,
+                          idlist_t *parent_relations) const override;
 
-    void get_way_parents(
-        osmium::index::IdSetSmall<osmid_t> const &changed_ways,
-        osmium::index::IdSetSmall<osmid_t> *parent_relations) const override;
+    void get_way_parents(idlist_t const &changed_ways,
+                         idlist_t *parent_relations) const override;
 
     class table_desc
     {

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -10,12 +10,12 @@
  * For a full list of authors see the git log.
  */
 
-#include <osmium/index/id_set.hpp>
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/entity_bits.hpp>
 
 #include <memory>
 
+#include "idlist.hpp"
 #include "osmtypes.hpp"
 #include "thread-pool.hpp"
 
@@ -149,16 +149,14 @@ public:
 #endif
     }
 
-    virtual void get_node_parents(
-        osmium::index::IdSetSmall<osmid_t> const & /*changed_nodes*/,
-        osmium::index::IdSetSmall<osmid_t> * /*parent_ways*/,
-        osmium::index::IdSetSmall<osmid_t> * /*parent_relations*/) const
+    virtual void get_node_parents(idlist_t const & /*changed_nodes*/,
+                                  idlist_t * /*parent_ways*/,
+                                  idlist_t * /*parent_relations*/) const
     {
     }
 
-    virtual void get_way_parents(
-        osmium::index::IdSetSmall<osmid_t> const & /*changed_ways*/,
-        osmium::index::IdSetSmall<osmid_t> * /*parent_relations*/) const
+    virtual void get_way_parents(idlist_t const & /*changed_ways*/,
+                                 idlist_t * /*parent_relations*/) const
     {
     }
 

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -15,9 +15,10 @@
 
 #include <memory>
 
-#include "idlist.hpp"
 #include "osmtypes.hpp"
 #include "thread-pool.hpp"
+
+class idlist_t;
 
 struct options_t;
 struct output_requirements;

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -364,7 +364,7 @@ void osmdata_t::process_dependents() const
     }
 
     // stage 1c processing: mark parent relations of marked objects as changed
-    auto marked_ways = m_output->get_marked_way_ids();
+    auto const &marked_ways = m_output->get_marked_way_ids();
     if (marked_ways.empty()) {
         return;
     }

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -244,8 +244,7 @@ private:
 
         std::lock_guard<std::mutex> const lock{*mutex};
         if (!queue->empty()) {
-            id = queue->back();
-            queue->pop_back();
+            id = queue->pop_id();
         }
 
         return id;

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -24,6 +24,7 @@
 #include <osmium/osm/box.hpp>
 
 #include "dependency-manager.hpp"
+#include "idlist.hpp"
 #include "osmtypes.hpp"
 #include "pgsql-params.hpp"
 

--- a/src/osmtypes.hpp
+++ b/src/osmtypes.hpp
@@ -238,23 +238,6 @@ private:
     std::vector<tag_t> m_tags;
 }; // class taglist_t
 
-struct idlist_t : public std::vector<osmid_t>
-{
-    // Get all constructors from std::vector
-    using vector<osmid_t>::vector;
-
-    // Even though we got all constructors from std::vector we need this on
-    // some compilers/libraries for some reason.
-    idlist_t() = default;
-
-    explicit idlist_t(osmium::NodeRefList const &list)
-    {
-        for (auto const &n : list) {
-            push_back(n.ref());
-        }
-    }
-};
-
 using rolelist_t = std::vector<char const *>;
 
 #endif // OSM2PGSQL_OSMTYPES_HPP

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -998,7 +998,7 @@ void output_flex_t::select_relation_members()
                     "integer way ids."};
             }
 
-            m_stage2_way_ids->set(id);
+            m_stage2_way_ids->push_back(id);
         });
 
     lua_pop(lua_state(), 2); // return value (a table), ways field (a table)
@@ -1486,7 +1486,7 @@ void output_flex_t::init_lua(std::string const &filename)
     lua_remove(lua_state(), 1); // global "osm2pgsql"
 }
 
-idset_t const &output_flex_t::get_marked_way_ids()
+idlist_t const &output_flex_t::get_marked_way_ids()
 {
     if (m_stage2_way_ids->empty()) {
         log_info("Skipping stage 1c (no marked ways).");

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -16,9 +16,9 @@
 #include "flex-table-column.hpp"
 #include "flex-table.hpp"
 #include "geom.hpp"
+#include "idlist.hpp"
 #include "output.hpp"
 
-#include <osmium/index/id_set.hpp>
 #include <osmium/osm/item_type.hpp>
 
 #include <lua.hpp>
@@ -34,8 +34,6 @@ class db_deleter_by_type_and_id_t;
 class geom_transform_t;
 class thread_pool_t;
 struct options_t;
-
-using idset_t = osmium::index::IdSetSmall<osmid_t>;
 
 /**
  * When C++ code is called from the Lua code we sometimes need to know
@@ -128,7 +126,7 @@ public:
 
     void wait() override;
 
-    idset_t const &get_marked_way_ids() override;
+    idlist_t const &get_marked_way_ids() override;
     void reprocess_marked() override;
 
     void pending_way(osmid_t id) override;
@@ -295,7 +293,7 @@ private:
 
     // This is shared between all clones of the output and must only be
     // accessed while protected using the lua_mutex.
-    std::shared_ptr<idset_t> m_stage2_way_ids = std::make_shared<idset_t>();
+    std::shared_ptr<idlist_t> m_stage2_way_ids = std::make_shared<idlist_t>();
 
     std::shared_ptr<db_copy_thread_t> m_copy_thread;
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -16,8 +16,8 @@
  * Common output layer interface.
  */
 
-#include <osmium/index/id_set.hpp>
-
+#include "idlist.hpp"
+#include "options.hpp"
 #include "osmtypes.hpp"
 #include "output-requirements.hpp"
 
@@ -68,9 +68,9 @@ public:
 
     virtual void wait() {}
 
-    virtual osmium::index::IdSetSmall<osmid_t> const &get_marked_way_ids()
+    virtual idlist_t const &get_marked_way_ids()
     {
-        static osmium::index::IdSetSmall<osmid_t> const ids{};
+        static idlist_t const ids{};
         return ids;
     }
 

--- a/src/pgsql-helper.cpp
+++ b/src/pgsql-helper.cpp
@@ -14,8 +14,9 @@
 #include <cassert>
 
 idlist_t get_ids_from_result(pg_result_t const &result) {
-    idlist_t ids;
     assert(result.num_tuples() >= 0);
+
+    idlist_t ids;
     ids.reserve(static_cast<std::size_t>(result.num_tuples()));
 
     for (int i = 0; i < result.num_tuples(); ++i) {

--- a/src/pgsql-helper.hpp
+++ b/src/pgsql-helper.hpp
@@ -10,6 +10,7 @@
  * For a full list of authors see the git log.
  */
 
+#include "idlist.hpp"
 #include "osmtypes.hpp"
 
 #include <string>

--- a/tests/common-buffer.hpp
+++ b/tests/common-buffer.hpp
@@ -11,6 +11,7 @@
  */
 
 #include "format.hpp"
+#include "idlist.hpp"
 #include "osmtypes.hpp"
 
 #include <osmium/memory/buffer.hpp>

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1118,7 +1118,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
 
         REQUIRE(dependency_manager.has_pending());
         idlist_t const way_ids = dependency_manager.get_pending_way_ids();
-        REQUIRE_THAT(way_ids, Catch::Equals<osmid_t>({20}));
+        REQUIRE(way_ids == idlist_t{20});
 
         check_way(mid, way20);
         check_way_nodes(mid, way20.id(), {&node10a, &node11});
@@ -1153,7 +1153,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
 
             REQUIRE(dependency_manager.has_pending());
             idlist_t const way_ids = dependency_manager.get_pending_way_ids();
-            REQUIRE_THAT(way_ids, Catch::Equals<osmid_t>({20, 22}));
+            REQUIRE(way_ids == idlist_t{20, 22});
 
             check_way(mid, way20);
             check_way_nodes(mid, way20.id(), {&node10a, &node11});
@@ -1265,7 +1265,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         REQUIRE(dependency_manager.has_pending());
         idlist_t const rel_ids = dependency_manager.get_pending_relation_ids();
 
-        REQUIRE_THAT(rel_ids, Catch::Equals<osmid_t>({30}));
+        REQUIRE(rel_ids == idlist_t{30});
         check_relation(mid, rel30);
     }
 
@@ -1286,9 +1286,9 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
 
         REQUIRE(dependency_manager.has_pending());
         idlist_t const way_ids = dependency_manager.get_pending_way_ids();
-        REQUIRE_THAT(way_ids, Catch::Equals<osmid_t>({20}));
+        REQUIRE(way_ids == idlist_t{20});
         idlist_t const rel_ids = dependency_manager.get_pending_relation_ids();
-        REQUIRE_THAT(rel_ids, Catch::Equals<osmid_t>({31}));
+        REQUIRE(rel_ids == idlist_t{31});
         check_relation(mid, rel31);
     }
 }


### PR DESCRIPTION
Refactor code that handles lists of ids. The old code used two datastructures, `idlist_t` which derives from the `std::vector` class and `osmium::index::IdSetSmall<osmid_t>`. The new code now only has one clean `idlist_t` class, which means there is less copying around of data.