### PR TITLE
Use std::filesystem instead of boost::filesystem

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -16,8 +16,7 @@ runs:
     - name: Install software
       run: |
         sudo apt-get install -yq --no-install-suggests --no-install-recommends \
-          libboost-filesystem-dev \
-          libboost-system-dev \
+          libboost-dev \
           libbz2-dev \
           libexpat1-dev \
           libopencv-dev \

--- a/.github/actions/win-install/action.yml
+++ b/.github/actions/win-install/action.yml
@@ -7,10 +7,8 @@ runs:
     - name: Install packages
       run: |
         vcpkg install \
-          boost-filesystem:x64-windows \
           boost-geometry:x64-windows \
           boost-property-tree:x64-windows \
-          boost-system:x64-windows \
           bzip2:x64-windows \
           expat:x64-windows \
           libpq:x64-windows \

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,8 +38,7 @@ jobs:
           sudo apt-get purge -yq postgresql*
           sudo apt-get update -qq
           sudo apt-get install -yq --no-install-suggests --no-install-recommends \
-            libboost-filesystem-dev \
-            libboost-system-dev \
+            libboost-dev \
             libbz2-dev \
             libexpat1-dev \
             liblua${LUA_VERSION}-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ else()
     message(STATUS "Building without Lua support")
 endif()
 
-find_package(Boost 1.50 REQUIRED COMPONENTS system filesystem)
+find_package(Boost 1.50 REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 find_package(PostgreSQL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ Required libraries are
 * [proj](https://proj.org/)
 * [bzip2](http://www.bzip.org/)
 * [zlib](https://www.zlib.net/)
-* [Boost libraries](https://www.boost.org/), including geometry, system and
-  filesystem
+* [Boost libraries](https://www.boost.org/) (for boost geometry)
 * [nlohmann/json](https://json.nlohmann.me/)
 * [OpenCV](https://opencv.org/) (Optional, for generalization only)
 * [potrace](https://potrace.sourceforge.net/) (Optional, for generalization only)
@@ -73,7 +72,7 @@ It also requires access to a database server running
 
 Make sure you have installed the development packages for the libraries
 mentioned in the requirements section and a C++ compiler which supports C++17.
-We officially support gcc >= 7.0 and clang >= 8.
+We officially support gcc >= 8.0 and clang >= 8.
 
 To rebuild the included man page you'll need the [pandoc](https://pandoc.org/)
 tool.
@@ -83,8 +82,8 @@ First install the dependencies.
 On a Debian or Ubuntu system, this can be done with:
 
 ```sh
-sudo apt-get install make cmake g++ libboost-dev libboost-system-dev \
-  libboost-filesystem-dev libexpat1-dev zlib1g-dev libpotrace-dev \
+sudo apt-get install make cmake g++ libboost-dev \
+  libexpat1-dev zlib1g-dev libpotrace-dev \
   libopencv-dev libbz2-dev libpq-dev libproj-dev lua5.3 liblua5.3-dev \
   pandoc nlohmann-json3-dev pyosmium
 ```

--- a/src/lua-setup.cpp
+++ b/src/lua-setup.cpp
@@ -13,7 +13,7 @@
 
 #include <lua.hpp>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 void setup_lua_environment(lua_State *lua_state, std::string const &filename,
                            bool append_mode)
@@ -29,9 +29,9 @@ void setup_lua_environment(lua_State *lua_state, std::string const &filename,
     luaX_add_table_str(lua_state, "version", get_osm2pgsql_short_version());
 
     std::string dir_path =
-        boost::filesystem::path{filename}.parent_path().string();
+        std::filesystem::path{filename}.parent_path().string();
     if (!dir_path.empty()) {
-        dir_path += boost::filesystem::path::preferred_separator;
+        dir_path += std::filesystem::path::preferred_separator;
     }
     luaX_add_table_str(lua_state, "config_dir", dir_path.c_str());
 

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -24,9 +24,8 @@
 
 #include <osmium/util/memory.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <exception>
+#include <filesystem>
 #include <memory>
 #include <utility>
 
@@ -104,10 +103,9 @@ static void store_properties(properties_t *properties, options_t const &options)
         properties->set_string("flat_node_file", "");
     } else {
         properties->set_string(
-            "flat_node_file",
-            boost::filesystem::absolute(
-                boost::filesystem::path{options.flat_node_file})
-                .string());
+            "flat_node_file", std::filesystem::absolute(
+                                  std::filesystem::path{options.flat_node_file})
+                                  .string());
     }
 
     properties->set_string("prefix", options.prefix);
@@ -121,7 +119,7 @@ static void store_properties(properties_t *properties, options_t const &options)
     } else {
         properties->set_string(
             "style",
-            boost::filesystem::absolute(boost::filesystem::path{options.style})
+            std::filesystem::absolute(std::filesystem::path{options.style})
                 .string());
     }
 
@@ -192,8 +190,8 @@ static void check_and_update_flat_node_file(properties_t *properties,
         }
     } else {
         const auto absolute_path =
-            boost::filesystem::absolute(
-                boost::filesystem::path{options->flat_node_file})
+            std::filesystem::absolute(
+                std::filesystem::path{options->flat_node_file})
                 .string();
 
         if (flat_node_file_from_import.empty()) {
@@ -288,7 +286,7 @@ static void check_and_update_style_file(properties_t *properties,
     }
 
     const auto absolute_path =
-        boost::filesystem::absolute(boost::filesystem::path{options->style})
+        std::filesystem::absolute(std::filesystem::path{options->style})
             .string();
 
     if (absolute_path == style_file_from_import) {

--- a/tests/common-cleanup.hpp
+++ b/tests/common-cleanup.hpp
@@ -12,9 +12,8 @@
 
 #include "format.hpp"
 
+#include <filesystem>
 #include <string>
-
-#include <boost/filesystem.hpp>
 
 namespace testing::cleanup {
 
@@ -44,9 +43,8 @@ private:
             return;
         }
 
-        boost::system::error_code ec;
-        boost::filesystem::remove(m_filename, ec);
-        if (ec && warn) {
+        std::error_code ec;
+        if (!std::filesystem::remove(m_filename, ec) && warn) {
             fmt::print(stderr, "WARNING: Unable to remove \"{}\": {}\n",
                        m_filename, ec.message());
         }


### PR DESCRIPTION
This changes the minimum GCC version supported from 7 to 8, because std::filesystem is only in glibc 8. All major distributions have support for this for a long time now.