### PR TITLE
Reduce dependencies for windows build

### DIFF
--- a/.github/actions/win-install/action.yml
+++ b/.github/actions/win-install/action.yml
@@ -8,13 +8,12 @@ runs:
       run: |
         vcpkg install \
           boost-geometry:x64-windows \
-          boost-property-tree:x64-windows \
-          bzip2:x64-windows \
+          bzip2[core]:x64-windows \
           expat:x64-windows \
           libpq:x64-windows \
           lua:x64-windows \
           nlohmann-json:x64-windows \
-          proj:x64-windows \
+          proj[core]:x64-windows \
           zlib:x64-windows
       shell: bash
     - name: Install psycopg2 and behave


### PR DESCRIPTION
Removes now unneeded boost-property-tree and reduces the proj and bzip2 dependencies to the core build. proj depends on large libraries like curl and tiff by default, which in turn bring in lzma. None of them are required for the core functionalities of osm2pgsql.

This means that some more exotic features of proj are no longer available with the windows binary we distribute. You can still build your own, if you need them.