### PR TITLE
Github actions: build on several macOS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-12" # latest
-#          - "macos-13" disabled, because it doesn't work due to some problem with Homebrew
+          - "macos-12"
+          - "macos-13"
+          - "macos-14" # latest
     runs-on: ${{ matrix.os }}
 
     env:
@@ -21,13 +22,11 @@ jobs:
       - name: Install prerequisites
         run: |
           brew install boost lua nlohmann-json opencv pandoc postgis potrace
-          pip3 install psycopg2 behave osmium
-          pg_ctl -D /usr/local/var/postgres init
-          pg_ctl -D /usr/local/var/postgres start
-          # Work around homebrew postgresql installation screw-up, see
-          # https://github.com/actions/runner-images/issues/6176
-          ln -s $(pg_config --libdir)/* /usr/local/lib/ || true
-          ln -s $(pg_config --includedir)/* /usr/local/include/
+          # --break-system-packages is needed on macOS 14
+          pip3 install --break-system-packages psycopg2 behave osmium
+          mkdir ~/postgres
+          pg_ctl -D ~/postgres init
+          pg_ctl -D ~/postgres start
         shell: bash
 
       - name: Setup database


### PR DESCRIPTION
PostgreSQL database is now installed in the runners home dir, because on macOS 14 the global install isn't allowed any more.