### PR TITLE
Remove the deprecated --tablespace-index option

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -229,13 +229,6 @@ depends on the output.
 no default.)
 .SH PGSQL OUTPUT OPTIONS
 .TP
--i, --tablespace-index=TABLESPC
-Store all indexes in the PostgreSQL tablespace \f[V]TABLESPC\f[R].
-This option also affects the middle tables.
-This option is deprecated.
-Use the --tablespace-slim-index and/or --tablespace-main-index options
-instead.
-.TP
 --tablespace-main-data=TABLESPC
 Store the data tables in the PostgreSQL tablespace \f[V]TABLESPC\f[R].
 .TP

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -198,11 +198,6 @@ mandatory for short options too.
 
 # PGSQL OUTPUT OPTIONS
 
--i, \--tablespace-index=TABLESPC
-:   Store all indexes in the PostgreSQL tablespace `TABLESPC`. This option
-    also affects the middle tables. This option is deprecated. Use the
-    \--tablespace-slim-index and/or \--tablespace-main-index options instead.
-
 \--tablespace-main-data=TABLESPC
 :   Store the data tables in the PostgreSQL tablespace `TABLESPC`.
 

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -584,13 +584,6 @@ options_t parse_command_line(int argc, char *argv[])
     // Tablespace options
     // ----------------------------------------------------------------------
 
-    std::string tablespace_index;
-    app.add_option("-i,--tablespace-index", tablespace_index)
-        ->description("Tablespace for indexes (sets default for "
-                      "--tablespace-(main|slim)-index).")
-        ->option_text("TBLSPC")
-        ->group("Tablespace options");
-
     app.add_option("--tablespace-main-data", options.tblsmain_data)
         ->description("Tablespace for main tables.")
         ->option_text("TBLSPC")
@@ -659,18 +652,6 @@ options_t parse_command_line(int argc, char *argv[])
 
     if (options.input_format == "auto") {
         options.input_format.clear();
-    }
-
-    if (!tablespace_index.empty()) {
-        log_warn(
-            "The option -i, --tablespace-index is deprecated. Use "
-            "--tablespace-slim-index and/or --tablespace-main-index instead.");
-        if (options.tblsmain_index.empty()) {
-            options.tblsmain_index = tablespace_index;
-        }
-        if (options.tblsslim_index.empty()) {
-            options.tblsslim_index = tablespace_index;
-        }
     }
 
     if (options.dbschema.empty()) {


### PR DESCRIPTION
Use --tablespace-slim-index and/or --tablespace-main-index instead.