### PR TITLE
Change separation in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
-osm2pgsql was written by Jon Burgess, Artem Pavlenko, Martijn van Oosterhout
+osm2pgsql was written by Jon Burgess, Artem Pavlenko, Martijn van Oosterhout,
 Sarah Hoffmann, Kai Krueger, Frederik Ramm, Brian Quinion, Matt Amos,
 Kevin Kreiser, Paul Norman, Jochen Topf and other OpenStreetMap project members.


### PR DESCRIPTION
Adds comma separating Martijn van Oosterhout and Sarah Hoffman.