### PR TITLE
Remove somewhat magical way of iterating over table columns

### DIFF
--- a/src/debug-output.cpp
+++ b/src/debug-output.cpp
@@ -48,7 +48,7 @@ void write_table_list_to_debug_log(std::vector<flex_table_t> const &tables)
     for (auto const &table : tables) {
         log_debug("- Table {}", qualified_name(table.schema(), table.name()));
         log_debug("  - columns:");
-        for (auto const &column : table) {
+        for (auto const &column : table.columns()) {
             log_debug(R"(    - "{}" {} ({}) not_null={} create_only={})",
                       column.name(), column.type_name(), column.sql_type_name(),
                       column.not_null(), column.create_only());

--- a/src/flex-lua-index.cpp
+++ b/src/flex-lua-index.cpp
@@ -20,7 +20,7 @@ static void check_and_add_column(flex_table_t const &table,
                                  std::vector<std::string> *columns,
                                  char const *column_name)
 {
-    auto const *column = util::find_by_name(table, column_name);
+    auto const *column = util::find_by_name(table.columns(), column_name);
     if (!column) {
         throw fmt_error("Unknown column '{}' in table '{}'.", column_name,
                         table.name());

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -260,7 +260,7 @@ static void enable_check_trigger(pg_conn_t const &db_connection,
 {
     std::string checks;
 
-    for (auto const &column : table) {
+    for (auto const &column : table.columns()) {
         if (column.is_geometry_column() && column.needs_isvalid()) {
             checks.append(fmt::format(
                 R"((NEW."{0}" IS NULL OR ST_IsValid(NEW."{0}")) AND )",

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -111,14 +111,9 @@ public:
 
     std::size_t num_columns() const noexcept { return m_columns.size(); }
 
-    std::vector<flex_table_column_t>::const_iterator begin() const noexcept
+    std::vector<flex_table_column_t> const &columns() const noexcept
     {
-        return m_columns.begin();
-    }
-
-    std::vector<flex_table_column_t>::const_iterator end() const noexcept
-    {
-        return m_columns.end();
+        return m_columns;
     }
 
     flex_table_column_t *find_column_by_name(std::string const &name)

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -643,7 +643,7 @@ int output_flex_t::table_insert()
     auto *copy_mgr = table_connection.copy_mgr();
 
     try {
-        for (auto const &column : table_connection.table()) {
+        for (auto const &column : table_connection.table().columns()) {
             if (column.create_only()) {
                 continue;
             }
@@ -681,7 +681,7 @@ int output_flex_t::table_columns()
     lua_createtable(lua_state(), (int)table.num_columns(), 0);
 
     int n = 0;
-    for (auto const &column : table) {
+    for (auto const &column : table.columns()) {
         lua_pushinteger(lua_state(), ++n);
         lua_newtable(lua_state());
 
@@ -1039,7 +1039,7 @@ void output_flex_t::delete_from_table(table_connection_t *table_connection,
         auto const num_tuples = result.num_tuples();
         if (num_tuples > 0) {
             int col = 0;
-            for (auto const &column : table_connection->table()) {
+            for (auto const &column : table_connection->table().columns()) {
                 if (column.has_expire()) {
                     for (int i = 0; i < num_tuples; ++i) {
                         auto const geom = ewkb_to_geom(result.get(i, col));


### PR DESCRIPTION
Use accessor function flex_table_t::columns() to get to a vector of columns instead of having begin()/end() functions on flex_table_t.