### PR TITLE
Add tile-based generalizer calling SQL commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ else()
                     src/gen/gen-rivers.cpp
                     src/gen/gen-tile-builtup.cpp
                     src/gen/gen-tile-raster.cpp
+                    src/gen/gen-tile-sql.cpp
                     src/gen/gen-tile-vector.cpp
                     src/gen/gen-tile.cpp
                     src/gen/params.cpp

--- a/src/gen/gen-create.cpp
+++ b/src/gen/gen-create.cpp
@@ -13,6 +13,7 @@
 #include "gen-rivers.hpp"
 #include "gen-tile-builtup.hpp"
 #include "gen-tile-raster.hpp"
+#include "gen-tile-sql.hpp"
 #include "gen-tile-vector.hpp"
 #include "params.hpp"
 
@@ -34,6 +35,9 @@ std::unique_ptr<gen_base_t> create_generalizer(std::string const &strategy,
         }
         if (strategy == "rivers") {
             return std::make_unique<gen_rivers_t>(connection, append, params);
+        }
+        if (strategy == "tile-sql") {
+            return std::make_unique<gen_tile_sql_t>(connection, append, params);
         }
         if (strategy == "vector-union") {
             return std::make_unique<gen_tile_vector_union_t>(connection, append,

--- a/src/gen/gen-tile-sql.cpp
+++ b/src/gen/gen-tile-sql.cpp
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2024 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "gen-tile-sql.hpp"
+
+#include "logging.hpp"
+#include "params.hpp"
+#include "pgsql.hpp"
+#include "tile.hpp"
+
+gen_tile_sql_t::gen_tile_sql_t(pg_conn_t *connection, bool append,
+                               params_t *params)
+: gen_tile_t(connection, append, params),
+  m_sql_template(get_params().get_string("sql"))
+{
+    check_src_dest_table_params_exist();
+}
+
+void gen_tile_sql_t::process(tile_t const &tile)
+{
+    connection().exec("BEGIN");
+    delete_existing(tile);
+
+    log_gen("Run SQL...");
+
+    params_t tmp_params;
+    tmp_params.set("ZOOM", tile.zoom());
+    tmp_params.set("X", tile.x());
+    tmp_params.set("Y", tile.y());
+    dbexec(tmp_params, m_sql_template);
+
+    connection().exec("COMMIT");
+    log_gen("Done.");
+}
+
+void gen_tile_sql_t::post()
+{
+    if (!append_mode()) {
+        dbexec("ANALYZE {dest}");
+    }
+}

--- a/src/gen/gen-tile-sql.hpp
+++ b/src/gen/gen-tile-sql.hpp
@@ -1,0 +1,35 @@
+#ifndef OSM2PGSQL_GEN_TILE_SQL_HPP
+#define OSM2PGSQL_GEN_TILE_SQL_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2024 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "gen-tile.hpp"
+
+#include <string>
+#include <string_view>
+
+class gen_tile_sql_t final : public gen_tile_t
+{
+public:
+    gen_tile_sql_t(pg_conn_t *connection, bool append, params_t *params);
+
+    ~gen_tile_sql_t() override = default;
+
+    void process(tile_t const &tile) override;
+
+    void post() override;
+
+    std::string_view strategy() const noexcept override { return "tile-sql"; }
+
+private:
+    std::string m_sql_template;
+};
+
+#endif // OSM2PGSQL_GEN_TILE_SQL_HPP


### PR DESCRIPTION
It is named "tile-sql". Parameters are "name", "src_table", "dest_table", "zoom", and "sql", the command to be called. Use {ZOOM}, {X}, and {Y} in the command to set the zoom level and tile coordinates.