### PR TITLE
New nodes and ways can't have existing parents

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -65,7 +65,14 @@ void osmdata_t::node(osmium::Node const &node)
         } else {
             m_output->node_delete(node.id());
         }
-        m_changed_nodes.push_back(node.id());
+
+        // Version 1 means this is a new node, so there can't be an existing
+        // way or relation referencing it, so we don't have to add that node
+        // to the list of changed nodes. If the input data doesn't contain
+        // object versions this will still work, because then the version is 0.
+        if (node.version() != 1) {
+            m_changed_nodes.push_back(node.id());
+        }
     } else if (has_tags_or_attrs) {
         m_output->node_add(node);
     }
@@ -103,7 +110,14 @@ void osmdata_t::way(osmium::Way &way)
         } else {
             m_output->way_delete(way.id());
         }
-        m_changed_ways.push_back(way.id());
+
+        // Version 1 means this is a new way, so there can't be an existing
+        // relation referencing it, so we don't have to add that way to the
+        // list of changed ways. If the input data doesn't contain object
+        // versions this will still work, because then the version is 0.
+        if (way.version() != 1) {
+            m_changed_ways.push_back(way.id());
+        }
     } else if (has_tags_or_attrs) {
         m_output->way_add(&way);
     }

--- a/tests/bdd/flex/way-change.feature
+++ b/tests/bdd/flex/way-change.feature
@@ -10,11 +10,11 @@ Feature: Changing ways in a flex database
     Scenario Outline:
         Given the OSM data:
             """
+            w10 v1 dV Tt1=yes Nn10,n11
             w11 v1 dV Tt1=yes Nn12,n13
             w12 v1 dV Tt2=yes Nn14,n15
             w13 v1 dV Ttboth=yes Nn16,n17
             w14 v1 dV Ttboth=yes Nn18,n19
-            w10 v1 dV Tt1=yes Nn10,n11
             r30 v1 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
             """
         When running osm2pgsql flex with parameters
@@ -56,18 +56,18 @@ Feature: Changing ways in a flex database
 
         Examples:
             | input                             | num_w10 |
-            | w10 v1 dV Tt2=yes Nn10,n11        | 0       |
-            | w10 v1 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
+            | w10 v2 dV Tt2=yes Nn10,n11        | 0       |
+            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
 
 
     Scenario Outline: change way from t2
         Given the OSM data
             """
+            w10 v1 dV Tt2=yes Nn10,n11
             w11 v1 dV Tt1=yes Nn12,n13
             w12 v1 dV Tt2=yes Nn14,n15
             w13 v1 dV Ttboth=yes Nn16,n17
             w14 v1 dV Ttboth=yes Nn18,n19
-            w10 v1 dV Tt2=yes Nn10,n11
             r30 v1 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
             """
         When running osm2pgsql flex with parameters
@@ -109,18 +109,18 @@ Feature: Changing ways in a flex database
 
         Examples:
             | input                             | num_w10 |
-            | w10 v1 dV Tt1=yes Nn10,n11        | 0       |
-            | w10 v1 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
+            | w10 v2 dV Tt1=yes Nn10,n11        | 0       |
+            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
 
 
     Scenario Outline: change way from t1 and t2
         Given the OSM data
             """
+            w10 v1 dV Tt1=yes,t2=yes Nn10,n11
             w11 v1 dV Tt1=yes Nn12,n13
             w12 v1 dV Tt2=yes Nn14,n15
             w13 v1 dV Ttboth=yes Nn16,n17
             w14 v1 dV Ttboth=yes Nn18,n19
-            w10 v1 dV Tt1=yes,t2=yes Nn10,n11
             r30 v1 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
             """
         When running osm2pgsql flex with parameters
@@ -166,18 +166,18 @@ Feature: Changing ways in a flex database
 
         Examples:
             | input                      | num_t1 | num_t2 |
-            | w10 v1 dV Tt1=yes Nn10,n11 | 1      | 0      |
-            | w10 v1 dV Tt2=yes Nn10,n11 | 0      | 1      |
+            | w10 v2 dV Tt1=yes Nn10,n11 | 1      | 0      |
+            | w10 v2 dV Tt2=yes Nn10,n11 | 0      | 1      |
 
 
     Scenario Outline: change valid geom to invalid geom
         Given the OSM data
             """
+            w10 v1 dV Tt1=yes,t2=yes,tboth=yes Nn10,n11
             w11 v1 dV Tt1=yes Nn12,n13
             w12 v1 dV Tt2=yes Nn14,n15
             w13 v1 dV Ttboth=yes Nn16,n17
             w14 v1 dV Ttboth=yes Nn18,n19
-            w10 v1 dV Tt1=yes,t2=yes,tboth=yes Nn10,n11
             r30 v1 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
             """
         When running osm2pgsql flex with parameters
@@ -223,11 +223,11 @@ Feature: Changing ways in a flex database
     Scenario: change invalid geom to valid geom
         Given the OSM data
             """
+            w10 v1 dV Tt1=yes,t2=yes,tboth=yes Nn10
             w11 v1 dV Tt1=yes Nn12,n13
             w12 v1 dV Tt2=yes Nn14,n15
             w13 v1 dV Ttboth=yes Nn16,n17
             w14 v1 dV Ttboth=yes Nn18,n19
-            w10 v1 dV Tt1=yes,t2=yes,tboth=yes Nn10
             r30 v1 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
             """
         When running osm2pgsql flex with parameters


### PR DESCRIPTION
New nodes or ways (ie with version=1) can't have parent ways or relations. So we don't have to add them to the list of "changed nodes" or "changed ways" to trigger re-processing of changed parents. This will save us a whole lot of effort looking for parents that are never there.

Note that we are checking for version != 1. In the (unlikely) case that there are no versions in the input file (making version == 0), everything will work as before.