### PR TITLE
Allow a limit to be set on expiry of line segments

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -313,6 +313,9 @@ Create a tile expiry list.
 -o, --expire-output=FILENAME
 Output file name for expired tiles list.
 .TP
+--expire-segment-length=SIZE
+Max length for a line segment to be expired.
+.TP
 --expire-bbox-size=SIZE
 Max size for a polygon to expire the whole polygon, not just the
 boundary.

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -278,6 +278,9 @@ mandatory for short options too.
 -o, \--expire-output=FILENAME
 :   Output file name for expired tiles list.
 
+\--expire-segment-length=SIZE
+:   Max length for a line segment to be expired.
+
 \--expire-bbox-size=SIZE
 :   Max size for a polygon to expire the whole polygon, not just the boundary.
 

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -460,6 +460,12 @@ options_t parse_command_line(int argc, char *argv[])
     // Expire options
     // ----------------------------------------------------------------------
 
+    // --expire-segment-length
+    app.add_option("--expire-segment-length", options.expire_tiles_max_segment)
+        ->description("Max length for a line segment to be expired (default: no limit).")
+        ->type_name("SIZE")
+        ->group("Expire options");
+
     // --expire-bbox-size
     app.add_option("--expire-bbox-size", options.expire_tiles_max_bbox)
         ->description("Max size for a polygon to expire the whole polygon, not "

--- a/src/expire-config.hpp
+++ b/src/expire-config.hpp
@@ -34,6 +34,11 @@ struct expire_config_t
     double buffer = 0.1;
 
     /**
+     * Maximum length of a line segment that will be expired.
+     */
+    double line_segment_limit = 0.0;
+
+    /**
      * Maximum width/heigth of bbox of a (multi)polygon before hybrid mode
      * expiry switches from full-area to boundary-only expire.
      */

--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -156,6 +156,11 @@ void expire_tiles::from_line_segment(geom::point_t const &a,
                                      geom::point_t const &b,
                                      expire_config_t const &expire_config)
 {
+    if (expire_config.line_segment_limit > 0.0 &&
+        distance(a, b) > expire_config.line_segment_limit) {
+        return;
+    }
+
     auto tilec_a = coords_to_tile(a);
     auto tilec_b = coords_to_tile(b);
 

--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -271,6 +271,15 @@ static void parse_and_set_expire_options(lua_State *lua_state,
             throw fmt_error("Unknown expire mode '{}'.", mode);
         }
 
+        lua_getfield(lua_state, -1, "line_segment_limit");
+        if (lua_isnumber(lua_state, -1)) {
+            config.line_segment_limit = lua_tonumber(lua_state, -1);
+        } else if (!lua_isnil(lua_state, -1)) {
+            throw std::runtime_error{"Optional expire field 'line_segment_limit' "
+                                     "must contain a number."};
+        }
+        lua_pop(lua_state, 1); // ""line_segment_limit"
+
         lua_getfield(lua_state, -1, "full_area_limit");
         if (lua_isnumber(lua_state, -1)) {
             if (config.mode != expire_mode::hybrid) {

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -95,6 +95,9 @@ struct options_t
 
     std::shared_ptr<reprojection> projection; ///< SRS of projection
 
+    /// Max length of line segment that will be expired
+    double expire_tiles_max_segment = 0.0;
+
     /// Max bbox size in either dimension to expire full bbox for a polygon
     double expire_tiles_max_bbox = 20000.0;
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1189,6 +1189,7 @@ output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
             if (table.has_geom_column() && table.geom_column().srid() == 3857) {
                 expire_config_t config{};
                 config.expire_output = m_expire_outputs->size() - 1;
+                config.line_segment_limit = options.expire_tiles_max_segment;
                 if (options.expire_tiles_max_bbox > 0.0) {
                     config.mode = expire_mode::hybrid;
                     config.full_area_limit = options.expire_tiles_max_bbox;

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -438,6 +438,7 @@ output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
   m_buffer(32768, osmium::memory::Buffer::auto_grow::yes),
   m_rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
+    m_expire_config.line_segment_limit = get_options()->expire_tiles_max_segment;
     m_expire_config.full_area_limit = get_options()->expire_tiles_max_bbox;
     if (get_options()->expire_tiles_max_bbox > 0.0) {
         m_expire_config.mode = expire_mode::hybrid;


### PR DESCRIPTION
Accidentally or deliberately moving a node a long way creates a long line segment which can expire large numbers of tiles causing disruption to the rendering process as osm2pgsql either runs out of memory or generates a huge list of tiles to expire.

Limiting expiry of long line segments prevents that and also helps reduce disruption of the resulting rendered maps with long lines that are almost certainly incorrect.