### PR TITLE
Remove special case for old PostGIS versions when clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ with other versions of those libraries (set the `EXTERNAL_*libname*` option to
 * [protozero](https://github.com/mapbox/protozero) (>= 1.6.3)
 
 It also requires access to a database server running
-[PostgreSQL](https://www.postgresql.org/) 9.6+ and
-[PostGIS](https://www.postgis.net/) 2.2+.
+[PostgreSQL](https://www.postgresql.org/) (version 9.6+ works, 13+ strongly
+recommended) and [PostGIS](https://www.postgis.net/) (version 2.5+).
 
 Make sure you have installed the development packages for the libraries
 mentioned in the requirements section and a C++ compiler which supports C++17.

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -81,6 +81,11 @@ static void check_db(options_t const &options)
 
     init_database_capabilities(db_connection);
 
+    auto const pv = get_postgis_version();
+    if (pv.major < 2 || (pv.major == 2 && pv.minor < 5)) {
+        throw std::runtime_error{"Need at least PostGIS version 2.5"};
+    }
+
     check_schema(options.dbschema);
     check_schema(options.middle_dbschema);
     check_schema(options.output_dbschema);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -195,28 +195,9 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
 
         log_info("Clustering table '{}' by geometry...", m_target->name());
 
-        std::string sql = fmt::format("CREATE TABLE {} {} AS SELECT * FROM {}",
-                                      qual_tmp_name, m_table_space, qual_name);
-
-        auto const postgis_version = get_postgis_version();
-
-        sql += " ORDER BY ";
-        if (postgis_version.major == 2 && postgis_version.minor < 4) {
-            log_debug("Using GeoHash for clustering table '{}'",
-                      m_target->name());
-            if (m_srid == "4326") {
-                sql += "ST_GeoHash(way,10)";
-            } else {
-                sql += "ST_GeoHash(ST_Transform(ST_Envelope(way),4326),10)";
-            }
-            sql += " COLLATE \"C\"";
-        } else {
-            log_debug("Using native order for clustering table '{}'",
-                      m_target->name());
-            // Since Postgis 2.4 the order function for geometries gives
-            // useful results.
-            sql += "way";
-        }
+        std::string const sql =
+            fmt::format("CREATE TABLE {} {} AS SELECT * FROM {} ORDER BY way",
+                        qual_tmp_name, m_table_space, qual_name);
 
         m_db_connection->exec(sql);
 


### PR DESCRIPTION
Ordering by geometry was done differently before PostGIS 2.4. This commit removed the old code and adds a check that PostGIS 3 is available.

For this specific case a check for PostGIS 2.4 or above would be sufficient, but PostGIS 3 is available for a long time now (it is in Debian Bullseye ("oldstable", released 2021) and Ubuntu 20.04).