### PR TITLE
Add CI build on Ubuntu 24.04

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -31,12 +31,12 @@ runs:
           postgresql-client postgresql-contrib-${POSTGRESQL_VERSION} \
           python3-setuptools \
           zlib1g-dev
-        pip3 install behave osmium
+        pip3 install $PIP_OPTION behave osmium
         if [ "$CC" = clang-8 ]; then sudo apt-get install -yq --no-install-suggests --no-install-recommends clang-8; fi
         if [ "$PSYCOPG" = "2"]; then
             sudo apt-get install -yq --no-install-suggests --no-install-recommends python3-psycopg2
         else
-            pip3 install psycopg
+            pip3 install $PIP_OPTION psycopg
         fi
       shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,24 @@ jobs:
       - uses: ./.github/actions/ubuntu-prerequisites
       - uses: ./.github/actions/build-and-test
 
+  ubuntu24-pg16-gcc14:
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: gcc-14
+      CXX: g++-14
+      LUA_VERSION: 5.4
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 16
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Debug
+      PSYCOPG: 3
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/build-and-test
+
   windows:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 3
+      PIP_OPTION: --break-system-packages
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Not sure abot the `--break-system-packages`, but that is the same fix we used on the new macOS builds.

Note that windows builds currently fail, this is unrelated. As far as I can tell it is already fixed in vcpkg, but Github needs to deploy the new vcpkg version.