### PR TITLE
Allow setting the index names in the flex output

### DIFF
--- a/flex-config/indexes.lua
+++ b/flex-config/indexes.lua
@@ -62,11 +62,14 @@ tables.roads = osm2pgsql.define_way_table('roads', {
 }})
 
 -- Instead of on a column (or columns) you can define an index on an expression.
+-- Indexes can be named (the default name is the one that PostgreSQL creates).
 tables.postboxes = osm2pgsql.define_node_table('postboxes', {
     { column = 'operator', type = 'text' },
     { column = 'geom', type = 'point', not_null = true },
 }, { indexes = {
-    { expression = 'lower(operator)', method = 'btree' },
+    { expression = 'lower(operator)',
+      method = 'btree',
+      name = 'postbox_operator_idx' },
 }})
 
 -- Helper function that looks at the tags and decides if this is possibly

--- a/src/debug-output.cpp
+++ b/src/debug-output.cpp
@@ -61,6 +61,11 @@ void write_table_list_to_debug_log(std::vector<flex_table_t> const &tables)
         log_debug("  - cluster={}", table.cluster_by_geom());
         for (auto const &index : table.indexes()) {
             log_debug("  - INDEX USING {}", index.method());
+            if (index.name().empty()) {
+                log_debug("    - name=(default name)");
+            } else {
+                log_debug("    - name={}", index.name());
+            }
             log_debug("    - column={}", index.columns());
             log_debug("    - expression={}", index.expression());
             log_debug("    - include={}", index.include_columns());

--- a/src/flex-index.cpp
+++ b/src/flex-index.cpp
@@ -30,7 +30,13 @@ flex_index_t::create_index(std::string const &qualified_table_name) const
         joiner.add("UNIQUE");
     }
 
-    joiner.add("INDEX ON");
+    joiner.add("INDEX");
+
+    if (!m_name.empty()) {
+        joiner.add(fmt::format(R"("{}")", m_name));
+    }
+
+    joiner.add("ON");
     joiner.add(qualified_table_name);
 
     joiner.add("USING");

--- a/src/flex-index.hpp
+++ b/src/flex-index.hpp
@@ -48,6 +48,13 @@ public:
         m_include_columns = columns;
     }
 
+    std::string const &name() const noexcept { return m_name; }
+
+    void set_name(std::string name)
+    {
+        m_name = std::move(name);
+    }
+
     std::string const &expression() const noexcept { return m_expression; }
 
     void set_expression(std::string expression)
@@ -89,6 +96,7 @@ public:
 private:
     std::vector<std::string> m_columns;
     std::vector<std::string> m_include_columns;
+    std::string m_name;
     std::string m_method;
     std::string m_expression;
     std::string m_tablespace;

--- a/src/flex-lua-index.cpp
+++ b/src/flex-lua-index.cpp
@@ -78,6 +78,12 @@ void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
     }
     lua_pop(lua_state, 1);
 
+    // get name
+    std::string const name =
+        luaX_get_table_string(lua_state, "name", -1, "Index definition", "");
+    lua_pop(lua_state, 1);
+    index.set_name(name);
+
     // get expression
     std::string const expression = luaX_get_table_string(
         lua_state, "expression", -1, "Index definition", "");


### PR DESCRIPTION
Usually the name chosen by PostgreSQL for an index is fine, but sometimes you want to use a better name, especially if you are using expression indexes.