### PR TITLE
Allow empty config file in flex output

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1172,8 +1172,7 @@ output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
     }
 
     if (m_tables->empty()) {
-        throw std::runtime_error{
-            "No tables defined in Lua config. Nothing to do!"};
+        log_warn("No output tables defined!");
     }
 
     // For backwards compatibility we add a "default" expire output to all

--- a/tests/bdd/flex/lua-basics.feature
+++ b/tests/bdd/flex/lua-basics.feature
@@ -9,10 +9,10 @@ Feature: Flex output uses a Lua config file
             print("stage=" .. osm2pgsql.stage)
             print("Table=" .. type(osm2pgsql.Table))
             """
-        Then running osm2pgsql flex fails
-        And the error output contains
+        When running osm2pgsql flex
+        Then the error output contains
             """
-            No tables defined in Lua config. Nothing to do!
+            No output tables defined
             """
         And the standard output contains
             """


### PR DESCRIPTION
No flex config file, or one that doesn't define any tables is usually not very useful. But it can be used in slim mode to have the middle tables only. Or it can be used to do some other processing or instead if the null output for testing.

We still output a warning, but no error any more if the style file is missing from the command line or if there are no tables defined.