### PR TITLE
Use anonymous namespaces instead of declaring static functions

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -31,7 +31,9 @@
 #include <thread> // for number of threads
 #include <vector>
 
-static osmium::Box parse_bbox_param(std::string const &arg)
+namespace {
+
+osmium::Box parse_bbox_param(std::string const &arg)
 {
     double minx = NAN;
     double maxx = NAN;
@@ -61,9 +63,8 @@ static osmium::Box parse_bbox_param(std::string const &arg)
     return osmium::Box{minx, miny, maxx, maxy};
 }
 
-static void parse_expire_tiles_param(char const *arg,
-                                     uint32_t *expire_tiles_zoom_min,
-                                     uint32_t *expire_tiles_zoom)
+void parse_expire_tiles_param(char const *arg, uint32_t *expire_tiles_zoom_min,
+                              uint32_t *expire_tiles_zoom)
 {
     if (!arg || arg[0] == '-') {
         throw std::runtime_error{"Missing argument for option --expire-tiles."
@@ -110,20 +111,7 @@ static void parse_expire_tiles_param(char const *arg,
                              " tile expiry must be separated by '-'."};
 }
 
-void print_version()
-{
-    fmt::print(stderr, "Build: {}\n", get_build_type());
-    fmt::print(stderr, "Compiled using the following library versions:\n");
-    fmt::print(stderr, "Libosmium {}\n", LIBOSMIUM_VERSION_STRING);
-    fmt::print(stderr, "Proj {}\n", get_proj_version());
-#ifdef HAVE_LUAJIT
-    fmt::print(stderr, "{} ({})\n", LUA_RELEASE, LUAJIT_VERSION);
-#else
-    fmt::print(stderr, "{}\n", LUA_RELEASE);
-#endif
-}
-
-static void check_options_non_slim(CLI::App const &app)
+void check_options_non_slim(CLI::App const &app)
 {
     std::vector<std::string> const slim_options = {
         "--flat-nodes",           "--middle-schema",
@@ -138,7 +126,7 @@ static void check_options_non_slim(CLI::App const &app)
     }
 }
 
-static void check_options_output_flex(CLI::App const &app)
+void check_options_output_flex(CLI::App const &app)
 {
     auto const ignored_options = app.get_options([](CLI::Option const *option) {
         return option->get_group() == "Pgsql output options" ||
@@ -154,7 +142,7 @@ static void check_options_output_flex(CLI::App const &app)
     }
 }
 
-static void check_options_output_null(CLI::App const &app)
+void check_options_output_null(CLI::App const &app)
 {
     auto const ignored_options = app.get_options([](CLI::Option const *option) {
         return option->get_group() == "Pgsql output options" ||
@@ -172,7 +160,7 @@ static void check_options_output_null(CLI::App const &app)
     }
 }
 
-static void check_options_output_pgsql(CLI::App const &app, options_t *options)
+void check_options_output_pgsql(CLI::App const &app, options_t *options)
 {
     if (app.count("--latlong") + app.count("--merc") + app.count("--proj") >
         1) {
@@ -196,7 +184,7 @@ static void check_options_output_pgsql(CLI::App const &app, options_t *options)
     }
 }
 
-static void check_options(options_t *options)
+void check_options(options_t *options)
 {
     if (options->append && !options->slim) {
         throw std::runtime_error{"--append can only be used with slim mode!"};
@@ -223,7 +211,7 @@ static void check_options(options_t *options)
     }
 }
 
-static void check_options_expire(options_t *options) {
+void check_options_expire(options_t *options) {
     // Zoom level 31 is the technical limit because we use 32-bit integers for
     // the x and y index of a tile ID.
     if (options->expire_tiles_zoom_min > 31) {
@@ -244,6 +232,25 @@ static void check_options_expire(options_t *options) {
                  "target SRS is not Mercator (EPSG:3857). Expire disabled!");
         options->expire_tiles_zoom = 0;
     }
+}
+
+} // anonymous namespace
+
+void print_version()
+{
+    fmt::print(stderr, "Build: {}\n", get_build_type());
+    fmt::print(stderr, "Compiled using the following library versions:\n");
+    fmt::print(stderr, "Libosmium {}\n", LIBOSMIUM_VERSION_STRING);
+    fmt::print(stderr, "Proj {}\n", get_proj_version());
+#ifdef HAVE_LUA
+#ifdef HAVE_LUAJIT
+    fmt::print(stderr, "{} ({})\n", LUA_RELEASE, LUAJIT_VERSION);
+#else
+    fmt::print(stderr, "{}\n", LUA_RELEASE);
+#endif
+#else
+    fmt::print(stderr, "Lua support not included\n");
+#endif
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)

--- a/src/flex-lua-expire-output.cpp
+++ b/src/flex-lua-expire-output.cpp
@@ -17,7 +17,9 @@
 
 #include <lua.hpp>
 
-static expire_output_t &
+namespace {
+
+expire_output_t &
 create_expire_output(lua_State *lua_state, std::string const &default_schema,
                      std::vector<expire_output_t> *expire_outputs)
 {
@@ -64,6 +66,8 @@ create_expire_output(lua_State *lua_state, std::string const &default_schema,
 
     return new_expire_output;
 }
+
+} // anonymous namespace
 
 int setup_flex_expire_output(lua_State *lua_state,
                              std::string const &default_schema,

--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -50,10 +50,12 @@ int geom_gc(lua_State *lua_state) noexcept
     return 0;
 }
 
+namespace {
+
 // The following functions are called when their counterparts in Lua are
 // called on geometry objects.
 
-static int geom_area(lua_State *lua_state)
+int geom_area(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -66,7 +68,7 @@ static int geom_area(lua_State *lua_state)
     return 1;
 }
 
-static int geom_spherical_area(lua_State *lua_state)
+int geom_spherical_area(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -84,7 +86,7 @@ static int geom_spherical_area(lua_State *lua_state)
     return 1;
 }
 
-static int geom_length(lua_State *lua_state)
+int geom_length(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     try {
@@ -96,7 +98,7 @@ static int geom_length(lua_State *lua_state)
     return 1;
 }
 
-static int geom_centroid(lua_State *lua_state)
+int geom_centroid(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -110,7 +112,7 @@ static int geom_centroid(lua_State *lua_state)
     return 1;
 }
 
-static int geom_geometry_n(lua_State *lua_state)
+int geom_geometry_n(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     auto const index = static_cast<int>(luaL_checkinteger(lua_state, 2));
@@ -125,7 +127,7 @@ static int geom_geometry_n(lua_State *lua_state)
     return 1;
 }
 
-static int geom_geometry_type(lua_State *lua_state)
+int geom_geometry_type(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -139,14 +141,14 @@ static int geom_geometry_type(lua_State *lua_state)
     return 1;
 }
 
-static int geom_is_null(lua_State *lua_state)
+int geom_is_null(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     lua_pushboolean(lua_state, input_geometry->is_null());
     return 1;
 }
 
-static int geom_reverse(lua_State *lua_state)
+int geom_reverse(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -160,7 +162,7 @@ static int geom_reverse(lua_State *lua_state)
     return 1;
 }
 
-static int geom_line_merge(lua_State *lua_state)
+int geom_line_merge(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -174,7 +176,7 @@ static int geom_line_merge(lua_State *lua_state)
     return 1;
 }
 
-static int geom_num_geometries(lua_State *lua_state)
+int geom_num_geometries(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     lua_pushinteger(lua_state,
@@ -182,7 +184,7 @@ static int geom_num_geometries(lua_State *lua_state)
     return 1;
 }
 
-static int geom_pole_of_inaccessibility(lua_State *lua_state)
+int geom_pole_of_inaccessibility(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
 
@@ -210,7 +212,7 @@ static int geom_pole_of_inaccessibility(lua_State *lua_state)
     return 1;
 }
 
-static int geom_segmentize(lua_State *lua_state)
+int geom_segmentize(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     double const max_segment_length = luaL_checknumber(lua_state, 2);
@@ -225,7 +227,7 @@ static int geom_segmentize(lua_State *lua_state)
     return 1;
 }
 
-static int geom_simplify(lua_State *lua_state)
+int geom_simplify(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     double const tolerance = luaL_checknumber(lua_state, 2);
@@ -240,7 +242,7 @@ static int geom_simplify(lua_State *lua_state)
     return 1;
 }
 
-static int geom_srid(lua_State *lua_state)
+int geom_srid(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     lua_pushinteger(lua_state,
@@ -251,12 +253,12 @@ static int geom_srid(lua_State *lua_state)
 // XXX Implementation for Lua __tostring function on geometries. Currently
 // just returns the type as string. This could be improved, for instance by
 // showing a WKT representation of the geometry.
-static int geom_tostring(lua_State *lua_state)
+int geom_tostring(lua_State *lua_state)
 {
     return geom_geometry_type(lua_state);
 }
 
-static int geom_transform(lua_State *lua_state)
+int geom_transform(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
     auto const srid = static_cast<int>(luaL_checkinteger(lua_state, 2));
@@ -274,6 +276,8 @@ static int geom_transform(lua_State *lua_state)
 
     return 1;
 }
+
+} // anonymous namespace
 
 void init_geometry_class(lua_State *lua_state)
 {

--- a/src/flex-lua-index.cpp
+++ b/src/flex-lua-index.cpp
@@ -16,9 +16,11 @@
 #include <string>
 #include <vector>
 
-static void check_and_add_column(flex_table_t const &table,
-                                 std::vector<std::string> *columns,
-                                 char const *column_name)
+namespace {
+
+void check_and_add_column(flex_table_t const &table,
+                          std::vector<std::string> *columns,
+                          char const *column_name)
 {
     auto const *column = util::find_by_name(table.columns(), column_name);
     if (!column) {
@@ -28,9 +30,9 @@ static void check_and_add_column(flex_table_t const &table,
     columns->emplace_back(column_name);
 }
 
-static void check_and_add_columns(flex_table_t const &table,
-                                  std::vector<std::string> *columns,
-                                  lua_State *lua_state)
+void check_and_add_columns(flex_table_t const &table,
+                           std::vector<std::string> *columns,
+                           lua_State *lua_state)
 {
     if (!luaX_is_array(lua_state)) {
         throw std::runtime_error{
@@ -45,6 +47,8 @@ static void check_and_add_columns(flex_table_t const &table,
         check_and_add_column(table, columns, lua_tostring(lua_state, -1));
     });
 }
+
+} // anonymous namespace
 
 void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
 {

--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -18,7 +18,9 @@
 
 #include <lua.hpp>
 
-static void check_tablespace(std::string const &tablespace)
+namespace {
+
+void check_tablespace(std::string const &tablespace)
 {
     if (!has_tablespace(tablespace)) {
         throw fmt_error(
@@ -28,9 +30,9 @@ static void check_tablespace(std::string const &tablespace)
     }
 }
 
-static flex_table_t &create_flex_table(lua_State *lua_state,
-                                       std::string const &default_schema,
-                                       std::vector<flex_table_t> *tables)
+flex_table_t &create_flex_table(lua_State *lua_state,
+                                std::string const &default_schema,
+                                std::vector<flex_table_t> *tables)
 {
     std::string const table_name =
         luaX_get_table_string(lua_state, "name", -1, "The table");
@@ -101,7 +103,7 @@ static flex_table_t &create_flex_table(lua_State *lua_state,
     return new_table;
 }
 
-static void parse_create_index(lua_State *lua_state, flex_table_t *table)
+void parse_create_index(lua_State *lua_state, flex_table_t *table)
 {
     std::string const create_index = luaX_get_table_string(
         lua_state, "create_index", -1, "The ids field", "auto");
@@ -117,8 +119,7 @@ static void parse_create_index(lua_State *lua_state, flex_table_t *table)
     }
 }
 
-static void setup_flex_table_id_columns(lua_State *lua_state,
-                                        flex_table_t *table)
+void setup_flex_table_id_columns(lua_State *lua_state, flex_table_t *table)
 {
     assert(lua_state);
     assert(table);
@@ -180,8 +181,8 @@ static void setup_flex_table_id_columns(lua_State *lua_state,
     lua_pop(lua_state, 1); // "ids"
 }
 
-static std::size_t idx_from_userdata(lua_State *lua_state, int idx,
-                                     std::size_t expire_outputs_size)
+std::size_t idx_from_userdata(lua_State *lua_state, int idx,
+                              std::size_t expire_outputs_size)
 {
     void const *const user_data = lua_touserdata(lua_state, idx);
 
@@ -202,10 +203,10 @@ static std::size_t idx_from_userdata(lua_State *lua_state, int idx,
     return eo;
 }
 
-static void parse_and_set_expire_options(lua_State *lua_state,
-                                         flex_table_column_t *column,
-                                         std::size_t expire_outputs_size,
-                                         bool append_mode)
+void parse_and_set_expire_options(lua_State *lua_state,
+                                  flex_table_column_t *column,
+                                  std::size_t expire_outputs_size,
+                                  bool append_mode)
 {
     auto const type = lua_type(lua_state, -1);
 
@@ -300,10 +301,9 @@ static void parse_and_set_expire_options(lua_State *lua_state,
     });
 }
 
-static void
-setup_flex_table_columns(lua_State *lua_state, flex_table_t *table,
-                         std::vector<expire_output_t> *expire_outputs,
-                         bool append_mode)
+void setup_flex_table_columns(lua_State *lua_state, flex_table_t *table,
+                              std::vector<expire_output_t> *expire_outputs,
+                              bool append_mode)
 {
     assert(lua_state);
     assert(table);
@@ -369,8 +369,8 @@ setup_flex_table_columns(lua_State *lua_state, flex_table_t *table,
     lua_pop(lua_state, 1); // "columns"
 }
 
-static void setup_flex_table_indexes(lua_State *lua_state, flex_table_t *table,
-                                     bool updatable)
+void setup_flex_table_indexes(lua_State *lua_state, flex_table_t *table,
+                              bool updatable)
 {
     assert(lua_state);
     assert(table);
@@ -412,6 +412,8 @@ static void setup_flex_table_indexes(lua_State *lua_state, flex_table_t *table,
 
     lua_pop(lua_state, 1); // "indexes"
 }
+
+} // anonymous namespace
 
 int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
                      std::vector<expire_output_t> *expire_outputs,

--- a/src/flex-table-column.cpp
+++ b/src/flex-table-column.cpp
@@ -19,6 +19,8 @@
 #include <utility>
 #include <vector>
 
+namespace {
+
 struct column_type_lookup
 {
     char const *m_name;
@@ -54,7 +56,7 @@ static std::vector<column_type_lookup> const column_types = {
      {"id_type", table_column_type::id_type},
      {"id_num", table_column_type::id_num}}};
 
-static table_column_type get_column_type_from_string(std::string const &type)
+table_column_type get_column_type_from_string(std::string const &type)
 {
     auto const *column_type = util::find_by_name(column_types, type);
     if (!column_type) {
@@ -64,7 +66,7 @@ static table_column_type get_column_type_from_string(std::string const &type)
     return column_type->type;
 }
 
-static std::string lowercase(std::string const &str)
+std::string lowercase(std::string const &str)
 {
     std::string result;
 
@@ -75,6 +77,8 @@ static std::string lowercase(std::string const &str)
 
     return result;
 }
+
+} // anonymous namespace
 
 flex_table_column_t::flex_table_column_t(std::string name,
                                          std::string const &type,

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -255,8 +255,10 @@ void flex_table_t::analyze(pg_conn_t const &db_connection) const
     analyze_table(db_connection, schema(), name());
 }
 
-static void enable_check_trigger(pg_conn_t const &db_connection,
-                                 flex_table_t const &table)
+namespace {
+
+void enable_check_trigger(pg_conn_t const &db_connection,
+                          flex_table_t const &table)
 {
     std::string checks;
 
@@ -278,6 +280,8 @@ static void enable_check_trigger(pg_conn_t const &db_connection,
     create_geom_check_trigger(db_connection, table.schema(), table.name(),
                               checks);
 }
+
+} // anonymous namespace
 
 void table_connection_t::start(pg_conn_t const &db_connection,
                                bool append) const

--- a/src/flex-write.cpp
+++ b/src/flex-write.cpp
@@ -22,7 +22,9 @@
 #include <limits>
 #include <vector>
 
-static int sgn(double val) noexcept
+namespace {
+
+int sgn(double val) noexcept
 {
     if (val > 0) {
         return 1;
@@ -33,8 +35,8 @@ static int sgn(double val) noexcept
     return 0;
 }
 
-static void write_null(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                       flex_table_column_t const &column)
+void write_null(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
+                flex_table_column_t const &column)
 {
     if (column.not_null()) {
         throw not_null_exception{
@@ -45,8 +47,8 @@ static void write_null(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
     copy_mgr->add_null_column();
 }
 
-static void write_boolean(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                          flex_table_column_t const &column, char const *str)
+void write_boolean(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
+                   flex_table_column_t const &column, char const *str)
 {
     if ((std::strcmp(str, "yes") == 0) || (std::strcmp(str, "true") == 0) ||
         std::strcmp(str, "1") == 0) {
@@ -63,9 +65,8 @@ static void write_boolean(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
     write_null(copy_mgr, column);
 }
 
-static void
-write_direction(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                flex_table_column_t const &column, char const *str)
+void write_direction(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
+                     flex_table_column_t const &column, char const *str)
 {
     if ((std::strcmp(str, "yes") == 0) || (std::strcmp(str, "1") == 0)) {
         copy_mgr->add_column(1);
@@ -112,8 +113,8 @@ void write_integer(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
     write_null(copy_mgr, column);
 }
 
-static void write_double(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                         flex_table_column_t const &column, char const *str)
+void write_double(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
+                  flex_table_column_t const &column, char const *str)
 {
     if (*str == '\0') {
         write_null(copy_mgr, column);
@@ -133,11 +134,11 @@ static void write_double(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
 
 using table_register_type = std::vector<void const *>;
 
-static void write_json(json_writer_t *writer, lua_State *lua_state,
-                       table_register_type *tables);
+void write_json(json_writer_t *writer, lua_State *lua_state,
+                table_register_type *tables);
 
-static void write_json_table(json_writer_t *writer, lua_State *lua_state,
-                             table_register_type *tables)
+void write_json_table(json_writer_t *writer, lua_State *lua_state,
+                      table_register_type *tables)
 {
     void const *table_ptr = lua_topointer(lua_state, -1);
     assert(table_ptr);
@@ -176,7 +177,7 @@ static void write_json_table(json_writer_t *writer, lua_State *lua_state,
     }
 }
 
-static void write_json_number(json_writer_t *writer, lua_State *lua_state)
+void write_json_number(json_writer_t *writer, lua_State *lua_state)
 {
 #if LUA_VERSION_NUM >= 503
     int okay = 0;
@@ -197,8 +198,8 @@ static void write_json_number(json_writer_t *writer, lua_State *lua_state)
 #endif
 }
 
-static void write_json(json_writer_t *writer, lua_State *lua_state,
-                       table_register_type *tables)
+void write_json(json_writer_t *writer, lua_State *lua_state,
+                table_register_type *tables)
 {
     assert(writer);
     assert(lua_state);
@@ -226,8 +227,8 @@ static void write_json(json_writer_t *writer, lua_State *lua_state,
     }
 }
 
-static bool is_compatible(geom::geometry_t const &geom,
-                          table_column_type type) noexcept
+bool is_compatible(geom::geometry_t const &geom,
+                   table_column_type type) noexcept
 {
     switch (type) {
     case table_column_type::geometry:
@@ -251,6 +252,8 @@ static bool is_compatible(geom::geometry_t const &geom,
     }
     return false;
 }
+
+} // anonymous namespace
 
 void flex_write_column(lua_State *lua_state,
                        db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,

--- a/src/gen/gen-base.cpp
+++ b/src/gen/gen-base.cpp
@@ -82,7 +82,9 @@ std::string gen_base_t::context()
     return gen_name.empty() ? "" : fmt::format(" '{}'", gen_name);
 }
 
-static pg_result_t dbexec_internal(
+namespace {
+
+pg_result_t dbexec_internal(
     pg_conn_t const &connection, std::string const &templ,
     fmt::dynamic_format_arg_store<fmt::format_context> const &format_store)
 {
@@ -94,6 +96,8 @@ static pg_result_t dbexec_internal(
         throw;
     }
 }
+
+} // anonymous namespace
 
 pg_result_t gen_base_t::dbexec(std::string const &templ)
 {

--- a/src/gen/gen-rivers.cpp
+++ b/src/gen/gen-rivers.cpp
@@ -76,10 +76,12 @@ bool operator<(geom::point_t a, edge_t const &b) noexcept
     return a < b.points[0];
 }
 
-static void
-follow_chain_and_set_width(edge_t const &edge, std::vector<edge_t> *edges,
-                           std::map<geom::point_t, uint8_t> const &node_order,
-                           geom::linestring_t *seen)
+namespace {
+
+void follow_chain_and_set_width(
+    edge_t const &edge, std::vector<edge_t> *edges,
+    std::map<geom::point_t, uint8_t> const &node_order,
+    geom::linestring_t *seen)
 {
     assert(!edge.points.empty());
 
@@ -115,9 +117,8 @@ follow_chain_and_set_width(edge_t const &edge, std::vector<edge_t> *edges,
     }
 }
 
-static void assemble_edge(edge_t *edge, std::vector<edge_t> *edges,
-                          std::map<geom::point_t, uint8_t> const &node_order)
-
+void assemble_edge(edge_t *edge, std::vector<edge_t> *edges,
+                   std::map<geom::point_t, uint8_t> const &node_order)
 {
     assert(edge);
     assert(edges);
@@ -165,6 +166,19 @@ static void assemble_edge(edge_t *edge, std::vector<edge_t> *edges,
     }
 }
 
+std::string const &get_name(
+    std::unordered_map<osmid_t, std::string> const &names, osmid_t id)
+{
+    static std::string const empty;
+    auto const it = names.find(id);
+    if (it == names.end()) {
+        return empty;
+    }
+    return it->second;
+}
+
+} // anonymous namespace
+
 /// Get some stats from source table
 void gen_rivers_t::get_stats()
 {
@@ -176,17 +190,6 @@ void gen_rivers_t::get_stats()
 
     log_gen("Found {} waterways with {} points.", m_num_waterways,
             m_num_points);
-}
-
-static std::string const &
-get_name(std::unordered_map<osmid_t, std::string> const &names, osmid_t id)
-{
-    static std::string const empty;
-    auto const it = names.find(id);
-    if (it == names.end()) {
-        return empty;
-    }
-    return it->second;
 }
 
 void gen_rivers_t::process()

--- a/src/gen/tracer.cpp
+++ b/src/gen/tracer.cpp
@@ -15,6 +15,19 @@
 #include <cmath>
 #include <stdexcept>
 
+static_assert(sizeof(potrace_word) == 8);
+
+namespace {
+
+potrace_word bit_squeeze(potrace_word w, unsigned char const *d) noexcept
+{
+    return (0x80U & d[0]) | (0x40U & d[1]) | (0x20U & d[2]) | (0x10U & d[3]) |
+           (0x08U & d[4]) | (0x04U & d[5]) | (0x02U & d[6]) | (0x01U & d[7]) |
+           w;
+}
+
+} // anonymous namespace
+
 geom::point_t tracer_t::make_point(potrace_dpoint_t const &p) const noexcept
 {
     return {p.x - static_cast<double>(m_buffer),
@@ -45,15 +58,6 @@ void tracer_t::reset()
     m_bits.clear();
     m_num_points = 0;
 }
-
-static potrace_word bit_squeeze(potrace_word w, unsigned char const *d) noexcept
-{
-    return (0x80U & d[0]) | (0x40U & d[1]) | (0x20U & d[2]) | (0x10U & d[3]) |
-           (0x08U & d[4]) | (0x04U & d[5]) | (0x02U & d[6]) | (0x01U & d[7]) |
-           w;
-}
-
-static_assert(sizeof(potrace_word) == 8);
 
 void tracer_t::prepare(canvas_t const &canvas) noexcept
 {

--- a/src/geom-pole-of-inaccessibility.cpp
+++ b/src/geom-pole-of-inaccessibility.cpp
@@ -39,9 +39,11 @@
 
 namespace geom {
 
+namespace {
+
 /// Get squared distance from a point p to a segment (a, b).
-static double point_to_segment_distance_squared(point_t p, point_t a, point_t b,
-                                                double stretch) noexcept
+double point_to_segment_distance_squared(point_t p, point_t a, point_t b,
+                                         double stretch) noexcept
 {
     double x = a.x();
     double y = a.y() * stretch;
@@ -68,9 +70,9 @@ static double point_to_segment_distance_squared(point_t p, point_t a, point_t b,
 }
 
 /// Get squared distance from a point p to ring.
-static bool point_to_ring_distance_squared(point_t point, ring_t const &ring,
-                                           bool inside, double stretch,
-                                           double *min_dist_squared) noexcept
+bool point_to_ring_distance_squared(point_t point, ring_t const &ring,
+                                    bool inside, double stretch,
+                                    double *min_dist_squared) noexcept
 {
     std::size_t const len = ring.size();
 
@@ -100,8 +102,8 @@ static bool point_to_ring_distance_squared(point_t point, ring_t const &ring,
  * Signed distance from point to polygon boundary. The result is negative if
  * the point is outside.
  */
-static auto point_to_polygon_distance(point_t point, polygon_t const &polygon,
-                                      double stretch)
+auto point_to_polygon_distance(point_t point, polygon_t const &polygon,
+                               double stretch)
 {
     double min_dist_squared = std::numeric_limits<double>::infinity();
 
@@ -115,8 +117,6 @@ static auto point_to_polygon_distance(point_t point, polygon_t const &polygon,
 
     return (inside ? 1 : -1) * std::sqrt(min_dist_squared);
 }
-
-namespace {
 
 struct Cell
 {
@@ -139,15 +139,15 @@ struct Cell
     }
 };
 
-} // anonymous namespace
-
-static Cell make_centroid_cell(polygon_t const &polygon, double stretch)
+Cell make_centroid_cell(polygon_t const &polygon, double stretch)
 {
     point_t centroid{0, 0};
     boost::geometry::centroid(polygon, centroid);
     centroid.set_y(stretch * centroid.y());
     return {centroid, 0, polygon, stretch};
 }
+
+} // anonymous namespace
 
 point_t pole_of_inaccessibility(const polygon_t &polygon, double precision,
                                 double stretch)

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -193,7 +193,9 @@ int luaX_pcall(lua_State *lua_state, int narg, int nres)
 
 #else
 
-static int pcall_error_traceback_handler(lua_State *lua_state)
+namespace {
+
+int pcall_error_traceback_handler(lua_State *lua_state)
 {
     assert(lua_state);
 
@@ -209,6 +211,8 @@ static int pcall_error_traceback_handler(lua_State *lua_state)
     luaL_traceback(lua_state, lua_state, msg, 1);
     return 1;
 }
+
+} // anonymous namespace
 
 /// Wrapper function for lua_pcall() showing a stack trace on error.
 int luaX_pcall(lua_State *lua_state, int narg, int nres)

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -28,12 +28,14 @@
 #include <memory>
 #include <utility>
 
+namespace {
+
 /**
  * Output overall memory usage as debug message.
  *
  * This only works on Linux.
  */
-static void show_memory_usage()
+void show_memory_usage()
 {
     osmium::MemoryUsage const mem;
     if (mem.peak() != 0) {
@@ -42,7 +44,7 @@ static void show_memory_usage()
     }
 }
 
-static file_info run(options_t const &options)
+file_info run(options_t const &options)
 {
     auto const files = prepare_input_files(
         options.input_files, options.input_format, options.append);
@@ -75,7 +77,7 @@ static file_info run(options_t const &options)
     return finfo;
 }
 
-static void check_db(options_t const &options)
+void check_db(options_t const &options)
 {
     pg_conn_t const db_connection{options.connection_params, "check"};
 
@@ -92,7 +94,7 @@ static void check_db(options_t const &options)
 }
 
 // This is called in "create" mode to store properties into the database.
-static void store_properties(properties_t *properties, options_t const &options)
+void store_properties(properties_t *properties, options_t const &options)
 {
     properties->set_bool("attributes", options.extra_attributes);
 
@@ -123,8 +125,7 @@ static void store_properties(properties_t *properties, options_t const &options)
     properties->store();
 }
 
-static void store_data_properties(properties_t *properties,
-                                  file_info const &finfo)
+void store_data_properties(properties_t *properties, file_info const &finfo)
 {
     if (finfo.last_timestamp.valid()) {
         auto const timestamp = finfo.last_timestamp.to_iso();
@@ -142,7 +143,7 @@ static void store_data_properties(properties_t *properties,
     properties->store();
 }
 
-static void check_updatable(properties_t const &properties)
+void check_updatable(properties_t const &properties)
 {
     if (properties.get_bool("updatable", false)) {
         return;
@@ -153,7 +154,7 @@ static void check_updatable(properties_t const &properties)
         " updatable database use --slim (without --drop)."};
 }
 
-static void check_attributes(properties_t const &properties, options_t *options)
+void check_attributes(properties_t const &properties, options_t *options)
 {
     bool const with_attributes = properties.get_bool("attributes", false);
 
@@ -172,8 +173,8 @@ static void check_attributes(properties_t const &properties, options_t *options)
     }
 }
 
-static void check_and_update_flat_node_file(properties_t *properties,
-                                            options_t *options)
+void check_and_update_flat_node_file(properties_t *properties,
+                                     options_t *options)
 {
     auto const flat_node_file_from_import =
         properties->get_string("flat_node_file", "");
@@ -210,7 +211,7 @@ static void check_and_update_flat_node_file(properties_t *properties,
     }
 }
 
-static void check_prefix(properties_t const &properties, options_t *options)
+void check_prefix(properties_t const &properties, options_t *options)
 {
     auto const prefix = properties.get_string("prefix", "planet_osm");
     if (!options->prefix_is_set) {
@@ -226,7 +227,7 @@ static void check_prefix(properties_t const &properties, options_t *options)
     }
 }
 
-static void check_db_format(properties_t const &properties, options_t *options)
+void check_db_format(properties_t const &properties, options_t *options)
 {
     auto const format = properties.get_int("db_format", -1);
 
@@ -243,7 +244,7 @@ static void check_db_format(properties_t const &properties, options_t *options)
     options->middle_database_format = static_cast<uint8_t>(format);
 }
 
-static void check_output(properties_t const &properties, options_t *options)
+void check_output(properties_t const &properties, options_t *options)
 {
     auto const output = properties.get_string("output", "pgsql");
 
@@ -262,8 +263,7 @@ static void check_output(properties_t const &properties, options_t *options)
                     options->output_backend, output);
 }
 
-static void check_and_update_style_file(properties_t *properties,
-                                        options_t *options)
+void check_and_update_style_file(properties_t *properties, options_t *options)
 {
     auto const style_file_from_import = properties->get_string("style", "");
 
@@ -296,8 +296,7 @@ static void check_and_update_style_file(properties_t *properties,
 
 // This is called in "append" mode to check that the command line options are
 // compatible with the properties stored in the database.
-static void check_and_update_properties(properties_t *properties,
-                                        options_t *options)
+void check_and_update_properties(properties_t *properties, options_t *options)
 {
     check_updatable(*properties);
     check_attributes(*properties, options);
@@ -308,7 +307,7 @@ static void check_and_update_properties(properties_t *properties,
     check_and_update_style_file(properties, options);
 }
 
-static void set_option_defaults(options_t *options)
+void set_option_defaults(options_t *options)
 {
     if (options->output_backend.empty()) {
         options->output_backend = "pgsql";
@@ -324,6 +323,8 @@ static void set_option_defaults(options_t *options)
         }
     }
 }
+
+} // anonymous namespace
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char *argv[])

--- a/src/pgsql-capabilities.cpp
+++ b/src/pgsql-capabilities.cpp
@@ -16,21 +16,26 @@
 
 #include <stdexcept>
 
-static database_capabilities_t &capabilities() noexcept
+namespace {
+
+database_capabilities_t &capabilities() noexcept
 {
     static database_capabilities_t c;
     return c;
 }
+
+} // anonymous namespace
 
 database_capabilities_t &database_capabilities_for_testing() noexcept
 {
     return capabilities();
 }
 
-static void init_set_from_query(std::set<std::string> *set,
-                                pg_conn_t const &db_connection,
-                                char const *table, char const *column,
-                                char const *condition = "true")
+namespace {
+
+void init_set_from_query(std::set<std::string> *set,
+                         pg_conn_t const &db_connection, char const *table,
+                         char const *column, char const *condition = "true")
 {
     set->clear(); // Clear existing in case this is called multiple times
 
@@ -42,7 +47,7 @@ static void init_set_from_query(std::set<std::string> *set,
 }
 
 /// Get all config settings from the database.
-static void init_settings(pg_conn_t const &db_connection)
+void init_settings(pg_conn_t const &db_connection)
 {
     capabilities().settings.clear(); // In case this is called multiple times
 
@@ -54,7 +59,7 @@ static void init_settings(pg_conn_t const &db_connection)
     }
 }
 
-static void init_database_name(pg_conn_t const &db_connection)
+void init_database_name(pg_conn_t const &db_connection)
 {
     auto const res = db_connection.exec("SELECT current_catalog");
 
@@ -66,7 +71,7 @@ static void init_database_name(pg_conn_t const &db_connection)
     capabilities().database_name = res.get(0, 0);
 }
 
-static void init_postgis_version(pg_conn_t const &db_connection)
+void init_postgis_version(pg_conn_t const &db_connection)
 {
     auto const res = db_connection.exec(
         "SELECT regexp_split_to_table(extversion, '\\.') FROM"
@@ -83,6 +88,8 @@ static void init_postgis_version(pg_conn_t const &db_connection)
     capabilities().postgis = {std::stoi(std::string{res.get(0, 0)}),
                               std::stoi(std::string{res.get(1, 0)})};
 }
+
+} // anonymous namespace
 
 void init_database_capabilities(pg_conn_t const &db_connection)
 {

--- a/src/progress-display.cpp
+++ b/src/progress-display.cpp
@@ -12,7 +12,9 @@
 #include "progress-display.hpp"
 #include "util.hpp"
 
-static double count_per_second(std::size_t count, uint64_t elapsed) noexcept
+namespace {
+
+double count_per_second(std::size_t count, uint64_t elapsed) noexcept
 {
     if (count == 0) {
         return 0.0;
@@ -25,7 +27,7 @@ static double count_per_second(std::size_t count, uint64_t elapsed) noexcept
     return static_cast<double>(count) / static_cast<double>(elapsed);
 }
 
-static std::string cps_display(std::size_t count, uint64_t elapsed)
+std::string cps_display(std::size_t count, uint64_t elapsed)
 {
     double const cps = count_per_second(count, elapsed);
 
@@ -34,6 +36,8 @@ static std::string cps_display(std::size_t count, uint64_t elapsed)
     }
     return fmt::format("{:.0f}/s", cps);
 }
+
+} // anonymous namespace
 
 void progress_display_t::print_summary() const
 {

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -64,10 +64,12 @@ unsigned parse_tag_flags(std::string const &flags, int lineno)
     return temp_flags;
 }
 
+namespace {
+
 /**
  * Get the tag type. For unknown types, 0 will be returned.
  */
-static unsigned get_tag_type(std::string const &tag)
+unsigned get_tag_type(std::string const &tag)
 {
     static std::map<std::string, unsigned> const tagtypes = {
         {"smallint", FLAG_INT_TYPE}, {"integer", FLAG_INT_TYPE},
@@ -82,6 +84,8 @@ static unsigned get_tag_type(std::string const &tag)
 
     return 0;
 }
+
+} // anonymous namespace
 
 bool read_style_file(std::string const &filename, export_list *exlist)
 {

--- a/src/tagtransform-c.cpp
+++ b/src/tagtransform-c.cpp
@@ -44,9 +44,7 @@ constexpr std::array<layers_type, 25> const layers = {
      {"primary", 37, true},        {"trunk", 38, true},
      {"motorway", 39, true}}};
 
-} // anonymous namespace
-
-static void add_z_order(taglist_t *tags, bool *roads)
+void add_z_order(taglist_t *tags, bool *roads)
 {
     std::string const *const layer = tags->get("layer");
     std::string const *const highway = tags->get("highway");
@@ -91,6 +89,13 @@ static void add_z_order(taglist_t *tags, bool *roads)
     tags->add_tag("z_order", fmt::to_string(z_order));
 }
 
+bool starts_with(char const *input, std::string const &test) noexcept
+{
+    return std::strncmp(input, test.c_str(), test.size()) == 0;
+}
+
+} // anonymous namespace
+
 c_tagtransform_t::c_tagtransform_t(options_t const *options, export_list exlist)
 : m_options(options), m_export_list(std::move(exlist))
 {}
@@ -98,11 +103,6 @@ c_tagtransform_t::c_tagtransform_t(options_t const *options, export_list exlist)
 std::unique_ptr<tagtransform_t> c_tagtransform_t::clone() const
 {
     return std::make_unique<c_tagtransform_t>(m_options, m_export_list);
-}
-
-static bool starts_with(char const *input, std::string const& test) noexcept
-{
-    return std::strncmp(input, test.c_str(), test.size()) == 0;
 }
 
 bool c_tagtransform_t::check_key(std::vector<taginfo> const &infos,

--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -45,10 +45,12 @@ void lua_tagtransform_t::check_lua_function_exists(char const *func_name)
     lua_pop(lua_state(), 1);
 }
 
+namespace {
+
 /**
  * Read tags from the Lua table on the stack and write them to out_tags
  */
-static void get_out_tags(lua_State *lua_state, taglist_t *out_tags)
+void get_out_tags(lua_State *lua_state, taglist_t *out_tags)
 {
     luaX_for_each(lua_state, [&]() {
         auto const key_type = lua_type(lua_state, -2);
@@ -76,6 +78,8 @@ static void get_out_tags(lua_State *lua_state, taglist_t *out_tags)
     });
     lua_pop(lua_state, 1);
 }
+
+} // anonymous namespace
 
 bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, bool *polygon,
                                      bool *roads, taglist_t *out_tags)

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -28,10 +28,12 @@ geom::point_t tile_t::center() const noexcept
     return to_world_coords({0.5, 0.5}, 1);
 }
 
+namespace {
+
 // Quadkey implementation uses bit interleaving code from
 // https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/blob/master/2018/01/08/interleave.c
 
-static uint64_t interleave_uint32_with_zeros(uint32_t input) noexcept
+uint64_t interleave_uint32_with_zeros(uint32_t input) noexcept
 {
     uint64_t word = input;
     word = (word ^ (word << 16U)) & 0x0000ffff0000ffffULL;
@@ -42,7 +44,7 @@ static uint64_t interleave_uint32_with_zeros(uint32_t input) noexcept
     return word;
 }
 
-static uint32_t deinterleave_lowuint32(uint64_t word) noexcept
+uint32_t deinterleave_lowuint32(uint64_t word) noexcept
 {
     word &= 0x5555555555555555ULL;
     word = (word ^ (word >> 1U)) & 0x3333333333333333ULL;
@@ -52,6 +54,8 @@ static uint32_t deinterleave_lowuint32(uint64_t word) noexcept
     word = (word ^ (word >> 16U)) & 0x00000000ffffffffULL;
     return static_cast<uint32_t>(word);
 }
+
+} // anonymous namespace
 
 quadkey_t tile_t::quadkey() const noexcept
 {


### PR DESCRIPTION
This is recommended in C++ Core Guidelines SF.22
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-unnamed2

Sorry for the long PR. This basically sticks a `namespace { ... } // anonymous namespace` around all sections that had static functions and removes the `static` keyword. In some cases I moved some functions around to consolidate several anon namespace sections into one. This is not consistently done though, in some case I thought it to be better to leave the anon section in the context of the code around it.