### PR TITLE
Remove option to disable BDD tests that require Lua

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -242,14 +242,10 @@ void print_version()
     fmt::print(stderr, "Compiled using the following library versions:\n");
     fmt::print(stderr, "Libosmium {}\n", LIBOSMIUM_VERSION_STRING);
     fmt::print(stderr, "Proj {}\n", get_proj_version());
-#ifdef HAVE_LUA
 #ifdef HAVE_LUAJIT
     fmt::print(stderr, "{} ({})\n", LUA_RELEASE, LUAJIT_VERSION);
 #else
     fmt::print(stderr, "{}\n", LUA_RELEASE);
-#endif
-#else
-    fmt::print(stderr, "Lua support not included\n");
 #endif
 }
 

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -38,7 +38,6 @@ USER_CONFIG = {
     'KEEP_TEST_DB': False,
     'TEST_DB': 'osm2pgsql-test',
     'HAVE_TABLESPACE': True,
-    'HAVE_LUA': True,
     'HAVE_PROJ': True
 }
 
@@ -93,9 +92,6 @@ def before_all(context):
     if proc.returncode != 0:
         raise RuntimeError('Cannot run osm2pgsql')
 
-    if context.config.userdata['HAVE_LUA']:
-        context.config.userdata['HAVE_LUA'] = 'Lua support not included' not in ver_info
-
     if context.config.userdata['HAVE_PROJ']:
         context.config.userdata['HAVE_PROJ'] = 'Proj [disabled]' not in ver_info
 
@@ -117,9 +113,6 @@ def before_scenario(context, scenario):
     """
     if 'config.have_proj' in scenario.tags and not context.config.userdata['HAVE_PROJ']:
         scenario.skip("Generic proj library not configured.")
-
-    if 'config.have_lua' in scenario.tags and not context.config.userdata['HAVE_LUA']:
-        scenario.skip("Lua support not compiled in.")
 
     context.db = use_fixture(test_db, context)
     context.import_file = None

--- a/tests/bdd/flex/lua-basics.feature
+++ b/tests/bdd/flex/lua-basics.feature
@@ -1,7 +1,9 @@
 Feature: Flex output uses a Lua config file
 
     Scenario: Check access to osm2pgsql object from Lua
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        Given the OSM data
+            """
+            """
         And the lua style
             """
             print("version=" .. osm2pgsql.version)
@@ -28,15 +30,17 @@ Feature: Flex output uses a Lua config file
             """
 
     Scenario: Check access to osm2pgsql properties from Lua
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        Given the OSM data
+            """
+            """
         And the lua style
             """
             local p = osm2pgsql.properties
             print("attributes=" .. p.attributes)
             print("prefix=" .. p.prefix)
             """
-        Then running osm2pgsql flex fails
-        And the standard output contains
+        When running osm2pgsql flex
+        Then the standard output contains
             """
             attributes=false
             """

--- a/tests/bdd/regression/properties.feature
+++ b/tests/bdd/regression/properties.feature
@@ -92,7 +92,6 @@ Feature: Updates to the test database with properties check
             Using style file '' (same as on import).
             """
 
-    @config.have_lua
     Scenario Outline: Create/append with various style parameters with flex output
         When running osm2pgsql flex with parameters
             | --slim         |

--- a/tests/bdd/steps/steps_execute.py
+++ b/tests/bdd/steps/steps_execute.py
@@ -121,19 +121,11 @@ def do_not_setup_tagtransform(context):
 
 @given("the default lua tagtransform")
 def setup_lua_tagtransform(context):
-    if not context.config.userdata['HAVE_LUA']:
-        context.scenario.skip("Lua support not compiled in.")
-        return
-
     context.osm2pgsql_params.extend(('--tag-transform-script',
                                     str(context.default_data_dir / 'style.lua')))
 
 @given("the lua style")
 def setup_inline_lua_style(context):
-    if not context.config.userdata['HAVE_LUA']:
-        context.scenario.skip("Lua support not compiled in.")
-        return
-
     outfile = context.workdir / 'inline_style.lua'
     outfile.write_text(context.text)
     context.osm2pgsql_params.extend(('-S', str(outfile)))
@@ -141,10 +133,6 @@ def setup_inline_lua_style(context):
 
 @given("the style file '(?P<style>.+)'")
 def setup_style_file(context, style):
-    if style.endswith('.lua') and not context.config.userdata['HAVE_LUA']:
-        context.scenario.skip("Lua support not compiled in.")
-        return
-
     context.osm2pgsql_params.extend(('-S', str(context.test_data_dir / style)))
 
 


### PR DESCRIPTION
Lua is now always compiled into osm2pgsql, so there is no need to disable tests that require Lua. This should solve the issue where we accidentally keep disabling the tests without noticing.

Also reverts an accidental revert of the change that removes HAVE_LUA in the version printout. And fixes a test that unexpectedly succeeded (which we didn't see because the Lua-enabled tests didn't run).