### PR TITLE
Add after_nodes/ways/relations() callback functions in Lua

### DIFF
--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -181,6 +181,9 @@ public:
 private:
     void select_relation_members();
 
+    /// Call a Lua function that was "prepared" earlier.
+    void call_lua_function(prepared_lua_function_t func);
+
     /**
      * Call a Lua function that was "prepared" earlier with the OSMObject
      * as its only parameter.
@@ -188,7 +191,9 @@ private:
     void call_lua_function(prepared_lua_function_t func,
                            osmium::OSMObject const &object);
 
-    /// Aquire the lua_mutex and the call `call_lua_function()`.
+    /// Aquire the lua_mutex and then call `call_lua_function()`.
+    void get_mutex_and_call_lua_function(prepared_lua_function_t func);
+
     void get_mutex_and_call_lua_function(prepared_lua_function_t func,
                                          osmium::OSMObject const &object);
 
@@ -296,6 +301,9 @@ private:
     prepared_lua_function_t m_process_way{};
     prepared_lua_function_t m_process_relation{};
     prepared_lua_function_t m_select_relation_members{};
+    prepared_lua_function_t m_after_nodes{};
+    prepared_lua_function_t m_after_ways{};
+    prepared_lua_function_t m_after_relations{};
 
     calling_context m_calling_context = calling_context::main;
 

--- a/tests/bdd/flex/lua-callbacks.feature
+++ b/tests/bdd/flex/lua-callbacks.feature
@@ -1,0 +1,49 @@
+Feature: Lua callbacks are called
+
+    Scenario: Check access to osm2pgsql object from Lua
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local nodes = 0
+            local ways = 0
+            local relations = 0
+            local n = 0
+
+            osm2pgsql.define_node_table('dummy', {})
+
+            function osm2pgsql.process_node(object)
+                nodes = nodes + 1
+            end
+
+            function osm2pgsql.process_way(object)
+                ways = ways + 1
+            end
+
+            function osm2pgsql.process_relation(object)
+                relations = relations + 1
+            end
+
+            local function out()
+                print(n .. 'n=' .. nodes .. '@')
+                print(n .. 'w=' .. ways .. '@')
+                print(n .. 'r=' .. relations .. '@')
+                n = n + 1
+            end
+
+            osm2pgsql.after_nodes = out
+            osm2pgsql.after_ways = out
+            osm2pgsql.after_relations = out
+            """
+        When running osm2pgsql flex
+        Then the standard output contains
+            """
+            0n=1562@
+            0w=0@
+            0r=0@
+            1n=1562@
+            1w=7105@
+            1r=0@
+            2n=1562@
+            2w=7105@
+            2r=113@
+            """


### PR DESCRIPTION
This allows some code to run after the initial stages of processing, i.e. between nodes and ways, ways and relations, and after relations.