### PR TITLE
Add get_bbox() function to geometries in Lua

### DIFF
--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "flex-lua-geom.hpp"
+#include "geom-box.hpp"
 #include "geom-functions.hpp"
 #include "geom-pole-of-inaccessibility.hpp"
 #include "lua-utils.hpp"
@@ -242,6 +243,23 @@ int geom_simplify(lua_State *lua_state)
     return 1;
 }
 
+int geom_get_bbox(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+
+    try {
+        auto const box = geom::envelope(*input_geometry);
+        lua_pushnumber(lua_state, box.min_x());
+        lua_pushnumber(lua_state, box.min_y());
+        lua_pushnumber(lua_state, box.max_x());
+        lua_pushnumber(lua_state, box.max_y());
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'get_bbox()'.\n");
+    }
+
+    return 4;
+}
+
 int geom_srid(lua_State *lua_state)
 {
     auto const *const input_geometry = unpack_geometry(lua_state);
@@ -298,6 +316,7 @@ void init_geometry_class(lua_State *lua_state)
     luaX_add_table_func(lua_state, "area", geom_area);
     luaX_add_table_func(lua_state, "length", geom_length);
     luaX_add_table_func(lua_state, "centroid", geom_centroid);
+    luaX_add_table_func(lua_state, "get_bbox", geom_get_bbox);
     luaX_add_table_func(lua_state, "geometry_n", geom_geometry_n);
     luaX_add_table_func(lua_state, "geometry_type", geom_geometry_type);
     luaX_add_table_func(lua_state, "is_null", geom_is_null);

--- a/tests/bdd/flex/bbox.feature
+++ b/tests/bdd/flex/bbox.feature
@@ -18,6 +18,11 @@ Feature: Test get_bbox() function
             function osm2pgsql.process_node(object)
                 local row = { geom = object:as_point() }
                 row.min_x, row.min_y, row.max_x, row.max_y = object:get_bbox()
+                local min_x, min_y, max_x, max_y = object:as_point():get_bbox()
+                assert(row.min_x == min_x)
+                assert(row.min_y == min_y)
+                assert(row.max_x == max_x)
+                assert(row.max_y == max_y)
                 points:insert(row)
             end
             """
@@ -53,6 +58,11 @@ Feature: Test get_bbox() function
             function osm2pgsql.process_way(object)
                 local row = { geom = object:as_linestring() }
                 row.min_x, row.min_y, row.max_x, row.max_y = object:get_bbox()
+                local min_x, min_y, max_x, max_y = object:as_linestring():get_bbox()
+                assert(row.min_x == min_x)
+                assert(row.min_y == min_y)
+                assert(row.max_x == max_x)
+                assert(row.max_y == max_y)
                 highways:insert(row)
             end
             """
@@ -93,6 +103,11 @@ Feature: Test get_bbox() function
                 row.min_x, row.min_y, row.max_x, row.max_y = object:get_bbox()
                 for sgeom in object:as_multilinestring():line_merge():geometries() do
                     row.geom = sgeom
+                    local min_x, min_y, max_x, max_y = sgeom:get_bbox()
+                    assert(row.min_x == min_x)
+                    assert(row.min_y == min_y)
+                    assert(row.max_x == max_x)
+                    assert(row.max_y == max_y)
                     rels:insert(row)
                 end
             end


### PR DESCRIPTION
Add new get_bbox() function for geometries in Lua. Like the get_bbox() function on OSM objects it returns the bounding box as four numbers in a Lua array (table). Having this function on geometries allows for more flexibility, you can call it on a centroid or a projected geometry for instance.

It is faster to call get_bbox() on the OSM object, because it removes the step of building the geometry first, so for those cases where this is good enough the old use is fine and is still supported.

See #2219

I have chosen the `get_bbox()` name instead of `envelope()`. a) this is consistent with `get_bbox()` on OSM objects and b) this leaves the option for adding a `envelope()` function later that returns a geometry, not a Lua array.