### PR TITLE
Refactor area assembler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(osm2pgsql_lib PRIVATE
     flex-table-column.cpp
     flex-table.cpp
     flex-write.cpp
+    geom-area-assembler.cpp
     geom-box.cpp
     geom-from-osm.cpp
     geom-functions.cpp

--- a/src/geom-area-assembler.cpp
+++ b/src/geom-area-assembler.cpp
@@ -1,0 +1,59 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2024 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "geom-area-assembler.hpp"
+
+#include <osmium/builder/osm_object_builder.hpp>
+
+namespace geom {
+
+const osmium::area::AssemblerConfig area_config;
+
+area_assembler_t::area_assembler_t(osmium::memory::Buffer *buffer)
+: osmium::area::detail::BasicAssembler(area_config), m_buffer(buffer)
+{
+}
+
+bool area_assembler_t::make_area()
+{
+    if (!create_rings()) {
+        return false;
+    }
+
+    m_buffer->clear();
+    {
+        osmium::builder::AreaBuilder builder{*m_buffer};
+        add_rings_to_area(builder);
+    }
+    m_buffer->commit();
+
+    return true;
+}
+
+bool area_assembler_t::operator()(const osmium::Way &way)
+{
+    segment_list().extract_segments_from_way(nullptr, stats().duplicate_nodes,
+                                             way);
+    return make_area();
+}
+
+// Currently the relation is not needed for assembling the area, because
+// the roles on the members are ignored. In the future we might want to use
+// the roles, so we leave the function signature as it is.
+bool area_assembler_t::operator()(const osmium::Relation & /*relation*/,
+                                  const osmium::memory::Buffer &ways_buffer)
+{
+    for (const auto &way : ways_buffer.select<osmium::Way>()) {
+        segment_list().extract_segments_from_way(nullptr,
+                                                 stats().duplicate_nodes, way);
+    }
+    return make_area();
+}
+
+} // namespace geom

--- a/src/geom-area-assembler.hpp
+++ b/src/geom-area-assembler.hpp
@@ -1,0 +1,67 @@
+#ifndef OSM2PGSQL_GEOM_AREA_ASSEMBLER_HPP
+#define OSM2PGSQL_GEOM_AREA_ASSEMBLER_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2024 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+/**
+ * \file
+ *
+ * Code for assembling areas from ways or relations.
+ */
+
+#include <osmium/area/detail/basic_assembler.hpp>
+
+namespace geom {
+
+/**
+ * The area_assembler_t class is a light wrapper around the libosmium class
+ * for assembling areas.
+ */
+class area_assembler_t : public osmium::area::detail::BasicAssembler
+{
+public:
+    area_assembler_t(osmium::memory::Buffer *buffer);
+
+    /**
+     * Assemble an area from the given way.
+     *
+     * @returns false if there was some kind of error building the
+     *          area, true otherwise.
+     */
+    bool operator()(const osmium::Way &way);
+
+    /**
+     * Assemble an area from the given relation and its member ways
+     * which are in the ways_buffer.
+     *
+     * @returns false if there was some kind of error building the
+     *          area, true otherwise.
+     */
+    bool operator()(const osmium::Relation &relation,
+                    const osmium::memory::Buffer &ways_buffer);
+
+    /**
+     * Access the area that was built last.
+     */
+    osmium::Area const &get_area() const noexcept
+    {
+        return m_buffer->get<osmium::Area>(0);
+    }
+
+private:
+    bool make_area();
+
+    osmium::memory::Buffer* m_buffer;
+
+}; // class area_assembler_t
+
+} // namespace geom
+
+#endif // OSM2PGSQL_GEOM_AREA_ASSEMBLER_HPP

--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -90,7 +90,8 @@ geometry_t create_linestring(osmium::Way const &way)
     return geom;
 }
 
-void create_polygon(geometry_t *geom, osmium::Way const &way)
+void create_polygon(geometry_t *geom, osmium::Way const &way,
+                    osmium::memory::Buffer *area_buffer)
 {
     auto &polygon = geom->set<polygon_t>();
 
@@ -100,8 +101,7 @@ void create_polygon(geometry_t *geom, osmium::Way const &way)
         return;
     }
 
-    osmium::memory::Buffer area_buffer{1024};
-    geom::area_assembler_t assembler{&area_buffer};
+    geom::area_assembler_t assembler{area_buffer};
 
     if (!assembler(way)) {
         geom->reset();
@@ -114,10 +114,11 @@ void create_polygon(geometry_t *geom, osmium::Way const &way)
     fill_point_list(&polygon.outer(), ring);
 }
 
-geometry_t create_polygon(osmium::Way const &way)
+geometry_t create_polygon(osmium::Way const &way,
+                          osmium::memory::Buffer *area_buffer)
 {
     geometry_t geom{};
-    create_polygon(&geom, way);
+    create_polygon(&geom, way, area_buffer);
     return geom;
 }
 
@@ -205,10 +206,10 @@ geometry_t create_multilinestring(osmium::memory::Buffer const &buffer,
 }
 
 void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
-                         osmium::memory::Buffer const &buffer)
+                         osmium::memory::Buffer const &buffer,
+                         osmium::memory::Buffer *area_buffer)
 {
-    osmium::memory::Buffer area_buffer{1024};
-    geom::area_assembler_t assembler{&area_buffer};
+    geom::area_assembler_t assembler{area_buffer};
 
     if (!assembler(relation, buffer)) {
         geom->reset();
@@ -231,10 +232,11 @@ void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
 }
 
 geometry_t create_multipolygon(osmium::Relation const &relation,
-                               osmium::memory::Buffer const &buffer)
+                               osmium::memory::Buffer const &buffer,
+                               osmium::memory::Buffer *area_buffer)
 {
     geometry_t geom{};
-    create_multipolygon(&geom, relation, buffer);
+    create_multipolygon(&geom, relation, buffer, area_buffer);
     return geom;
 }
 

--- a/src/geom-from-osm.hpp
+++ b/src/geom-from-osm.hpp
@@ -76,8 +76,10 @@ void create_linestring(geometry_t *geom, osmium::Way const &way);
  *
  * \param geom Pointer to an existing geometry which will be used as output.
  * \param way The input way.
+ * \param area_buffer Temporary buffer used to create area.
  */
-void create_polygon(geometry_t *geom, osmium::Way const &way);
+void create_polygon(geometry_t *geom, osmium::Way const &way,
+                    osmium::memory::Buffer *area_buffer);
 
 /**
  * Create a polygon geometry from a way.
@@ -85,9 +87,11 @@ void create_polygon(geometry_t *geom, osmium::Way const &way);
  * If the resulting polygon would be invalid, a null geometry is returned.
  *
  * \param way The input way.
+ * \param area_buffer Temporary buffer used to create area.
  * \returns The created geometry.
  */
-[[nodiscard]] geometry_t create_polygon(osmium::Way const &way);
+[[nodiscard]] geometry_t create_polygon(osmium::Way const &way,
+                                        osmium::memory::Buffer *area_buffer);
 
 /**
  * Create a multipoint geometry from a bunch of nodes (usually this would be
@@ -163,9 +167,11 @@ create_multilinestring(osmium::memory::Buffer const &buffer,
  * \param geom Pointer to an existing geometry which will be used as output.
  * \param relation The input relation.
  * \param buffer Buffer with OSM objects. Anything but ways are ignored.
+ * \param area_buffer Temporary buffer used to create area.
  */
 void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
-                         osmium::memory::Buffer const &buffer);
+                         osmium::memory::Buffer const &buffer,
+                         osmium::memory::Buffer *area_buffer);
 
 /**
  * Create a (multi)polygon geometry from a relation and member ways.
@@ -175,11 +181,13 @@ void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
  *
  * \param relation The input relation.
  * \param buffer Buffer with OSM objects. Anything but ways are ignored.
+ * \param area_buffer Temporary buffer used to create area.
  * \returns The created geometry.
  */
 [[nodiscard]] geometry_t
 create_multipolygon(osmium::Relation const &relation,
-                    osmium::memory::Buffer const &buffer);
+                    osmium::memory::Buffer const &buffer,
+                    osmium::memory::Buffer *area_buffer);
 
 /**
  * Create a geometry collection from nodes and ways, usually used for

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -400,7 +400,7 @@ int output_flex_t::app_as_polygon()
     m_way_cache.add_nodes(middle());
 
     auto *geom = create_lua_geometry_object(lua_state());
-    geom::create_polygon(geom, m_way_cache.get());
+    geom::create_polygon(geom, m_way_cache.get(), &m_area_buffer);
 
     return 1;
 }
@@ -459,7 +459,7 @@ int output_flex_t::app_as_multipolygon()
         m_way_cache.add_nodes(middle());
 
         auto *geom = create_lua_geometry_object(lua_state());
-        geom::create_polygon(geom, m_way_cache.get());
+        geom::create_polygon(geom, m_way_cache.get(), &m_area_buffer);
 
         return 1;
     }
@@ -468,7 +468,8 @@ int output_flex_t::app_as_multipolygon()
 
     auto *geom = create_lua_geometry_object(lua_state());
     geom::create_multipolygon(geom, m_relation_cache.get(),
-                              m_relation_cache.members_buffer());
+                              m_relation_cache.members_buffer(),
+                              &m_area_buffer);
 
     return 1;
 }
@@ -1173,6 +1174,7 @@ output_flex_t::output_flex_t(output_flex_t const *other,
   m_db_connection(get_options()->connection_params, "out.flex.thread"),
   m_stage2_way_ids(other->m_stage2_way_ids),
   m_copy_thread(std::move(copy_thread)), m_lua_state(other->m_lua_state),
+  m_area_buffer(1024, osmium::memory::Buffer::auto_grow::yes),
   m_process_node(other->m_process_node), m_process_way(other->m_process_way),
   m_process_relation(other->m_process_relation),
   m_select_relation_members(other->m_select_relation_members),
@@ -1203,7 +1205,8 @@ output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
                              properties_t const &properties)
 : output_t(mid, std::move(thread_pool), options),
   m_db_connection(get_options()->connection_params, "out.flex.main"),
-  m_copy_thread(std::make_shared<db_copy_thread_t>(options.connection_params))
+  m_copy_thread(std::make_shared<db_copy_thread_t>(options.connection_params)),
+  m_area_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
     init_lua(options.style, properties);
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -297,6 +297,8 @@ private:
     relation_cache_t m_relation_cache;
     osmium::Node const *m_context_node = nullptr;
 
+    osmium::memory::Buffer m_area_buffer;
+
     prepared_lua_function_t m_process_node{};
     prepared_lua_function_t m_process_way{};
     prepared_lua_function_t m_process_relation{};

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -109,6 +109,7 @@ private:
 
     osmium::memory::Buffer m_buffer;
     osmium::memory::Buffer m_rels_buffer;
+    osmium::memory::Buffer m_area_buffer;
 };
 
 #endif // OSM2PGSQL_OUTPUT_PGSQL_HPP

--- a/tests/test-geom-multipolygons.cpp
+++ b/tests/test-geom-multipolygons.cpp
@@ -70,7 +70,9 @@ TEST_CASE("create_multipolygon creates simple polygon from OSM data", "[NoDB]")
     buffer.add_way("w21 Nn4x1y2,n1x1y1");
     auto const &relation = buffer.add_relation("r30 Mw20@,w21@");
 
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_polygon());
     REQUIRE(geometry_type(geom) == "POLYGON");
@@ -92,7 +94,9 @@ TEST_CASE("create_multipolygon from OSM data", "[NoDB]")
     buffer.add_way("w22 Nn5x10y10,n6x10y20,n7x20y20,n5x10y10");
     auto const &relation = buffer.add_relation("r30 Mw20@,w21@,w22@");
 
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_multipolygon());
     REQUIRE(geometry_type(geom) == "MULTIPOLYGON");
@@ -107,7 +111,9 @@ TEST_CASE("create_multipolygon from OSM data without locations", "[NoDB]")
     buffer.add_way("w20 Nn1,n2,n3,n1");
 
     auto const &relation = buffer.add_relation("r30 Mw20@");
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -118,7 +124,9 @@ TEST_CASE("create_multipolygon from invalid OSM data (single node)", "[NoDB]")
     buffer.add_way("w20 Nn1x1y1");
 
     auto const &relation = buffer.add_relation("r30 Mw20@");
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -130,7 +138,9 @@ TEST_CASE("create_multipolygon from invalid OSM data (way node closed)",
     buffer.add_way("w20 Nn1x1y1,n2x2y2");
 
     auto const &relation = buffer.add_relation("r30 Mw20@");
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -143,7 +153,9 @@ TEST_CASE("create_multipolygon from invalid OSM data (self-intersection)",
     buffer.add_way("w21 Nn4x2y2,n1x1y1");
 
     auto const &relation = buffer.add_relation("r30 Mw20@,w21@");
-    auto const geom = geom::create_multipolygon(relation, buffer.buffer());
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_multipolygon(relation, buffer.buffer(), &area_buffer);
 
     REQUIRE(geom.is_null());
 }

--- a/tests/test-geom-polygons.cpp
+++ b/tests/test-geom-polygons.cpp
@@ -85,7 +85,9 @@ TEST_CASE("create_polygon from OSM data", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1x1y1,n2x2y1,n3x2y2,n4x1y2,n1x1y1");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_polygon());
     REQUIRE(geometry_type(geom) == "POLYGON");
@@ -104,7 +106,9 @@ TEST_CASE("create_polygon from OSM data (reverse)", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1x1y1,n2x1y2,n3x2y2,n4x2y1,n1x1y1");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_polygon());
     REQUIRE(geometry_type(geom) == "POLYGON");
@@ -122,7 +126,9 @@ TEST_CASE("create_polygon from OSM data without locations", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1,n2,n3,n1");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -132,7 +138,9 @@ TEST_CASE("create_polygon from invalid OSM data (single node)", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1x1y1");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -142,7 +150,9 @@ TEST_CASE("create_polygon from invalid OSM data (way node closed)", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1x1y1,n2x2y2");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_null());
 }
@@ -152,7 +162,9 @@ TEST_CASE("create_polygon from invalid OSM data (self-intersection)", "[NoDB]")
     test_buffer_t buffer;
     buffer.add_way("w20 Nn1x1y1,n2x1y2,n3x2y1,n4x2y2,n1x1y1");
 
-    auto const geom = geom::create_polygon(buffer.buffer().get<osmium::Way>(0));
+    osmium::memory::Buffer area_buffer{1024};
+    auto const geom =
+        geom::create_polygon(buffer.buffer().get<osmium::Way>(0), &area_buffer);
 
     REQUIRE(geom.is_null());
 }


### PR DESCRIPTION
The area assembler code we were using from libosmium was doing a few unnecessary things. This implements our own class which only does what's necessary.

We also reuse the memory buffer where we assemble the areas, which saves us from constant memory allocations.

Will not have a huge impact, but doing less work is always good.