### PR TITLE
Github actions: Add clang-tidy run to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '*,-abseil-*,-altera-*,-android-cloexec-*,-bugprone-easily-swappable-parameters,-cert-err58-cpp,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-vararg,-fuchsia-*,-google-readability-casting,-google-readability-todo,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-vararg,-llvm-include-order,-llvm-header-guard,-llvmlibc-*,-misc-no-recursion,-modernize-use-nodiscard,-modernize-use-trailing-return-type,-readability-identifier-length,-readability-implicit-bool-conversion,-readability-named-parameter,-readability-magic-numbers'
+Checks: '*,-abseil-*,-altera-*,-android-cloexec-*,-bugprone-easily-swappable-parameters,-cert-err58-cpp,-cppcoreguidelines-avoid-do-while,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-vararg,-fuchsia-*,-google-readability-casting,-google-readability-todo,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-vararg,-llvm-include-order,-llvm-header-guard,-llvmlibc-*,-misc-include-cleaner,-misc-no-recursion,-misc-use-anonymous-namespace,-modernize-use-nodiscard,-modernize-use-trailing-return-type,-readability-identifier-length,-readability-implicit-bool-conversion,-readability-named-parameter,-readability-magic-numbers'
 #
 #  cppcoreguidelines-pro-type-cstyle-cast
 #  google-build-using-namespace
@@ -25,6 +25,10 @@ Checks: '*,-abseil-*,-altera-*,-android-cloexec-*,-bugprone-easily-swappable-par
 #  cert-err58-cpp
 #    There are many of these in the test code, most of them from the Catch
 #    framework. Difficult to avoid.
+#
+#  cppcoreguidelines-avoid-do-while (new in clang-tidy-16)
+#    Its a good idea to avoid them when there are better alternatives, but
+#    sometimes they are the cleanest alternative.
 #
 #  cppcoreguidelines-avoid-magic-numbers
 #  readability-magic-numbers
@@ -55,8 +59,14 @@ Checks: '*,-abseil-*,-altera-*,-android-cloexec-*,-bugprone-easily-swappable-par
 #  llvmlibc-*
 #    Not applicable
 #
+#  misc-include-cleaner (new in clang-tidy-17)
+#    Many instances of this warning, disabled for now. (TODO)
+#
 #  misc-no-recursion
 #    Nothing wrong with recursion
+#
+#  misc-use-anonymous-namespace (new in clang-tidy-16)
+#    Lots of these, need some time to fix. (TODO)
 #
 #  modernize-use-nodiscard
 #    We have a lot of these. Remove it for the time being because there are

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -10,28 +10,6 @@ runs:
     using: composite
 
     steps:
-      - name: create build directory
-        run: mkdir build
-        shell: bash
-
-      - name: configure
-        run: |
-          CMAKE_OPTIONS="-LA -DBUILD_TESTS=ON -DWITH_LUAJIT=${LUAJIT_OPTION}"
-          if [ -n "$WITH_PROJ" ]; then
-            CMAKE_OPTIONS="$CMAKE_OPTIONS -DWITH_PROJ=$WITH_PROJ"
-          fi
-          if [ -n "$CPP_VERSION" ]; then
-            CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_CXX_STANDARD=$CPP_VERSION"
-          fi
-          if [ -n "$BUILD_TYPE" ]; then
-            CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
-          fi
-          cmake $CMAKE_OPTIONS ..
-        shell: bash
-        working-directory: build
-        env:
-          CXXFLAGS: -pedantic -Wextra ${{ env.EXTRA_FLAGS }} -Werror
-
       - name: build
         run: make -j3 all man
         shell: bash

--- a/.github/actions/clang-tidy/action.yml
+++ b/.github/actions/clang-tidy/action.yml
@@ -1,0 +1,9 @@
+name: Run clang-tidy
+
+runs:
+    using: composite
+
+    steps:
+      - name: Run clang-tidy
+        run: run-clang-tidy-17 -q -p build
+        shell: bash

--- a/.github/actions/linux-cmake/action.yml
+++ b/.github/actions/linux-cmake/action.yml
@@ -1,0 +1,28 @@
+name: CMake
+
+runs:
+    using: composite
+
+    steps:
+      - name: create build directory
+        run: mkdir build
+        shell: bash
+
+      - name: configure
+        run: |
+          CMAKE_OPTIONS="-LA -DBUILD_TESTS=ON -DWITH_LUAJIT=${LUAJIT_OPTION}"
+          if [ -n "$WITH_PROJ" ]; then
+            CMAKE_OPTIONS="$CMAKE_OPTIONS -DWITH_PROJ=$WITH_PROJ"
+          fi
+          if [ -n "$CPP_VERSION" ]; then
+            CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_CXX_STANDARD=$CPP_VERSION"
+          fi
+          if [ -n "$BUILD_TYPE" ]; then
+            CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
+          fi
+          cmake $CMAKE_OPTIONS ..
+        shell: bash
+        working-directory: build
+        env:
+          CXXFLAGS: -pedantic -Wextra ${{ env.EXTRA_FLAGS }} -Werror
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           psql -d postgres -c "CREATE TABLESPACE tablespacetest LOCATION '$GITHUB_WORKSPACE/tablespacetest'"
         shell: bash
 
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
         with:
           test-wrapper: ''
@@ -65,6 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg96-clang10-jit:
@@ -83,6 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg10-gcc10:
@@ -102,6 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
 
@@ -121,6 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg13-gcc10-jit:
@@ -139,6 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
 
@@ -158,6 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg15-clang10-noproj:
@@ -177,6 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg16-clang10:
@@ -195,6 +203,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu20-pg13-gcc10-release:
@@ -213,6 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-clang14-jit:
@@ -231,6 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-clang14-proj:
@@ -249,6 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-clang14-noproj:
@@ -268,6 +280,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg15-clang14:
@@ -286,6 +299,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-gcc12-release:
@@ -305,6 +319,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-clang15-cpp20:
@@ -324,6 +339,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu22-pg16-gcc12-cpp20:
@@ -343,6 +359,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   ubuntu24-pg16-gcc14:
@@ -362,6 +379,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
   windows:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,25 @@
+name: clang-tidy
+
+on: [ push, pull_request ]
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: clang-18
+      CXX: clang++-18
+      LUA_VERSION: 5.4
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 16
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Debug
+      PSYCOPG: 3
+      PIP_OPTION: --break-system-packages
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
+      - uses: ./.github/actions/clang-tidy
+


### PR DESCRIPTION
Currently CI will not fail if there are warnings from clang-tidy. This is, for the time being, only a way to easily see the messages.

Clang-tidy has its own workflow, so it doesn't interfere with the rest. But because it also needs cmake to run, the cmake run has been taken out of the 'build-and-test' action and put into its own.

This commit also disables some clang-tidy warnings we get from newer versions of clang-tidy.