### PR TITLE
Changed handling of object attributes in flex output

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,15 @@ stds.osm2pgsql = {
                 process_relation = {
                     read_only = false
                 },
+                process_untagged_node = {
+                    read_only = false
+                },
+                process_untagged_way = {
+                    read_only = false
+                },
+                process_untagged_relation = {
+                    read_only = false
+                },
                 select_relation_members = {
                     read_only = false
                 },

--- a/flex-config/untagged.lua
+++ b/flex-config/untagged.lua
@@ -1,0 +1,44 @@
+-- This config example file is released into the Public Domain.
+--
+-- Most of the time we are only interested in nodes, ways, and relations that
+-- have tags. But we can also get the untagged ones if necessary by using
+-- the processing functions 'process_untagged_node', 'process_untagged_way',
+-- and 'process_untagged_relation', respectively.
+
+local nodes = osm2pgsql.define_node_table('nodes', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'point' },
+})
+
+local ways = osm2pgsql.define_way_table('ways', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring' },
+})
+
+function osm2pgsql.process_node(object)
+    nodes:insert({
+        tags = object.tags,
+        geom = object:as_point(),
+    })
+end
+
+function osm2pgsql.process_untagged_node(object)
+    nodes:insert({
+        geom = object:as_point(),
+    })
+end
+
+-- If you want to use the same function in both cases, that's also quite easy.
+-- For instance like this:
+
+local function do_way(object)
+    ways:insert({
+        tags = object.tags,
+        geom = object:as_linestring(),
+    })
+end
+
+osm2pgsql.process_way = do_way
+osm2pgsql.process_untagged_way = do_way
+
+

--- a/src/init.lua
+++ b/src/init.lua
@@ -168,16 +168,6 @@ end
 
 -- This will be the metatable for the OSM objects given to the process callback
 -- functions.
-local inner_metatable = {
-    __index = function(table, key)
-        if key == 'version' or key == 'timestamp' or
-           key == 'changeset' or key == 'uid' or key == 'user' then
-            return nil
-        end
-        error("unknown field '" .. key .. "'", 2)
-    end
-}
-
 object_metatable = {
     __index =  {
         grab_tag = function(data, tag)
@@ -190,8 +180,6 @@ object_metatable = {
         end
     }
 }
-
-setmetatable(object_metatable.__index, inner_metatable)
 
 -- This is used to iterate over (multi)geometries.
 function osm2pgsql.Geometry.geometries(geom)

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -31,7 +31,9 @@ osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid,
 : m_mid(std::move(mid)), m_output(std::move(output)),
   m_connection_params(options.connection_params), m_bbox(options.bbox),
   m_num_procs(options.num_procs), m_append(options.append),
-  m_droptemp(options.droptemp), m_with_extra_attrs(options.extra_attributes)
+  m_droptemp(options.droptemp),
+  m_with_extra_attrs(options.extra_attributes ||
+                     options.output_backend == "flex")
 {
     assert(m_mid);
     assert(m_output);

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -305,8 +305,10 @@ void output_flex_t::check_context_and_state(char const *name,
                                             char const *context, bool condition)
 {
     if (condition) {
-        throw fmt_error("The function {}() can only be called from the {}.",
-                        name, context);
+        throw fmt_error(
+            "The function {}() can only be called (directly or indirectly) "
+            "from the process_[untagged]_{}() functions.",
+            name, context);
     }
 
     if (lua_gettop(lua_state()) > 1) {
@@ -317,7 +319,7 @@ void output_flex_t::check_context_and_state(char const *name,
 int output_flex_t::app_get_bbox()
 {
     check_context_and_state(
-        "get_bbox", "process_node/way/relation() functions",
+        "get_bbox", "node/way/relation",
         m_calling_context != calling_context::process_node &&
             m_calling_context != calling_context::process_way &&
             m_calling_context != calling_context::process_relation);
@@ -367,7 +369,7 @@ int output_flex_t::app_get_bbox()
 
 int output_flex_t::app_as_point()
 {
-    check_context_and_state("as_point", "process_node() function",
+    check_context_and_state("as_point", "node",
                             m_calling_context != calling_context::process_node);
 
     auto *geom = create_lua_geometry_object(lua_state());
@@ -378,7 +380,7 @@ int output_flex_t::app_as_point()
 
 int output_flex_t::app_as_linestring()
 {
-    check_context_and_state("as_linestring", "process_way() function",
+    check_context_and_state("as_linestring", "way",
                             m_calling_context != calling_context::process_way);
 
     m_way_cache.add_nodes(middle());
@@ -391,7 +393,7 @@ int output_flex_t::app_as_linestring()
 
 int output_flex_t::app_as_polygon()
 {
-    check_context_and_state("as_polygon", "process_way() function",
+    check_context_and_state("as_polygon", "way",
                             m_calling_context != calling_context::process_way);
 
     m_way_cache.add_nodes(middle());
@@ -405,7 +407,7 @@ int output_flex_t::app_as_polygon()
 int output_flex_t::app_as_multipoint()
 {
     check_context_and_state(
-        "as_multipoint", "process_node/relation() functions",
+        "as_multipoint", "node/relation",
         m_calling_context != calling_context::process_node &&
             m_calling_context != calling_context::process_relation);
 
@@ -423,10 +425,10 @@ int output_flex_t::app_as_multipoint()
 
 int output_flex_t::app_as_multilinestring()
 {
-    check_context_and_state(
-        "as_multilinestring", "process_way/relation() functions",
-        m_calling_context != calling_context::process_way &&
-            m_calling_context != calling_context::process_relation);
+    check_context_and_state("as_multilinestring", "way/relation",
+                            m_calling_context != calling_context::process_way &&
+                                m_calling_context !=
+                                    calling_context::process_relation);
 
     if (m_calling_context == calling_context::process_way) {
         m_way_cache.add_nodes(middle());
@@ -447,10 +449,10 @@ int output_flex_t::app_as_multilinestring()
 
 int output_flex_t::app_as_multipolygon()
 {
-    check_context_and_state(
-        "as_multipolygon", "process_way/relation() functions",
-        m_calling_context != calling_context::process_way &&
-            m_calling_context != calling_context::process_relation);
+    check_context_and_state("as_multipolygon", "way/relation",
+                            m_calling_context != calling_context::process_way &&
+                                m_calling_context !=
+                                    calling_context::process_relation);
 
     if (m_calling_context == calling_context::process_way) {
         m_way_cache.add_nodes(middle());
@@ -473,9 +475,9 @@ int output_flex_t::app_as_multipolygon()
 
 int output_flex_t::app_as_geometrycollection()
 {
-    check_context_and_state(
-        "as_geometrycollection", "process_relation() function",
-        m_calling_context != calling_context::process_relation);
+    check_context_and_state("as_geometrycollection", "relation",
+                            m_calling_context !=
+                                calling_context::process_relation);
 
     m_relation_cache.add_members(middle());
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -301,7 +301,13 @@ private:
     prepared_lua_function_t m_process_node{};
     prepared_lua_function_t m_process_way{};
     prepared_lua_function_t m_process_relation{};
+
+    prepared_lua_function_t m_process_untagged_node{};
+    prepared_lua_function_t m_process_untagged_way{};
+    prepared_lua_function_t m_process_untagged_relation{};
+
     prepared_lua_function_t m_select_relation_members{};
+
     prepared_lua_function_t m_after_nodes{};
     prepared_lua_function_t m_after_ways{};
     prepared_lua_function_t m_after_relations{};

--- a/tests/bdd/flex/extra-attributes.feature
+++ b/tests/bdd/flex/extra-attributes.feature
@@ -36,8 +36,8 @@ Feature: Tests for including extra attributes
             | --slim |
 
         Then table osm2pgsql_test_attr contains
-            | type | way_id | tags->'highway' | tags->'osm_version' |  version | changeset | timestamp | uid  | "user" |
-            | way  | 20     | primary         | NULL                |  NULL    | NULL      | NULL      | NULL | NULL   |
+            | type | way_id | tags->'highway' | tags->'osm_version' | version | changeset | timestamp  | uid  | "user" |
+            | way  | 20     | primary         | NULL                | 1       | 31        | 1578832496 | 17   | test   |
 
         Given the grid
             |    |    |


### PR DESCRIPTION
This is a backwards incompatible change in the way we are handling objects attributes (version, timestamp, changeset, uid, user) and the -x/--extra-attributes option in the flex output. The pgsql output is unaffected.

Old behaviour:
* If -x is set: attributes are available in Lua
* If -x is set: **all** objects are sent to the process functions, not only tagged objects
* If -x is set: Attributes are stored in middle tables in slim mode

New behaviour:
* Attributes are always available in Lua if they are in the data
* Only tagged objects are sent to the `process_node|way|relation` functions. There are new functions `process_untagged_node|way|relation` that are always called for untagged objects if they are defined.
* If -x is set: Attributes are stored in middle tables in slim mode (as before)

This separates out the three concerns (availability of attributes in Lua config, handling of untagged objects, and storage of attributes in middle).

Fixes #1680
Fixes #189