### PR TITLE
Remove support for non-bucket index on middle way table

### DIFF
--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -173,10 +173,6 @@ mandatory for short options too.
     database user. By default the schema set with `--schema` is used, or
     `public` if that is not set.
 
-\--middle-way-node-index-id-shift=SHIFT
-:   Set ID shift for way node bucket index in middle. Experts only. See
-    documentation for details.
-
 \--middle-with-nodes
 :   Used together with the **new** middle database format when a flat nodes
     file is used to force storing nodes with tags in the database, too.

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -136,12 +136,8 @@ void parse_expire_tiles_param(char const *arg, uint32_t *expire_tiles_zoom_min,
 void check_options_non_slim(CLI::App const &app)
 {
     std::vector<std::string> const slim_options = {
-        "--cache",
-        "--middle-schema",
-        "--middle-with-nodes",
-        "--middle-way-node-index-id-shift",
-        "--tablespace-slim-data",
-        "--tablespace-slim-index"};
+        "--cache", "--middle-schema", "--middle-with-nodes",
+        "--tablespace-slim-data", "--tablespace-slim-index"};
 
     for (auto const &opt : slim_options) {
         if (app.count(opt) > 0) {
@@ -573,13 +569,6 @@ options_t parse_command_line(int argc, char *argv[])
     app.add_flag_function("-I,--disable-parallel-indexing",
                           [&](int64_t) { options.parallel_indexing = false; })
         ->description("Disable concurrent index creation.")
-        ->group("Advanced options");
-
-    // --middle-way-node-index-id-shift
-    app.add_option("--middle-way-node-index-id-shift",
-                   options.way_node_index_id_shift)
-        ->description("Set ID shift for bucket index.")
-        ->type_name("N")
         ->group("Advanced options");
 
     // --number-processes

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -39,9 +39,6 @@ struct middle_pgsql_options
     // Store untagged nodes also (set in addition to nodes=true).
     bool untagged_nodes = false;
 
-    // Bit shift used in way node index
-    uint8_t way_node_index_id_shift = 5;
-
     // Use a flat node file
     bool use_flat_node_file = false;
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -108,14 +108,6 @@ struct options_t
     unsigned int num_procs = 1;
 
     /**
-     * How many bits should the node id be shifted for the way node index?
-     * The result is a lossy index which is significantly smaller.
-     * See https://osm2pgsql.org/doc/manual.html#bucket-index-for-slim-mode
-     * Use 0 to use a classic loss-less GIN index.
-     */
-    uint8_t way_node_index_id_shift = 5;
-
-    /**
      * Middle database format:
      * 0 = non-slim mode, no database middle (ram middle)
      * 1 = slim mode, legacy database format (not used any more)


### PR DESCRIPTION
Only supports bucket index which has been the default for a long time and works much better than the old one.

Also removes the command line option --middle-way-node-index-id-shift. The id shift can not be changed any more, it is hardcoded to 5 which was the default.

This is a potentially breaking change: Users with incompatible indexes have to do a reimport (or at least create the new index).