### PR TITLE
Make property handling more robust

### DIFF
--- a/src/gen/osm2pgsql-gen.cpp
+++ b/src/gen/osm2pgsql-gen.cpp
@@ -730,7 +730,11 @@ int main(int argc, char *argv[])
         }
 
         properties_t properties{connection_params, middle_dbschema};
-        properties.load();
+        if (!properties.load()) {
+            throw std::runtime_error{
+                "Did not find table 'osm2pgsql_properties' in database. "
+                "Database too old? Wrong schema?"};
+        }
 
         if (style.empty()) {
             style = properties.get_string("style", "");

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -44,7 +44,7 @@ void show_memory_usage()
     }
 }
 
-file_info run(options_t const &options, properties_t const &properties)
+file_info run(options_t const &options, properties_t *properties)
 {
     auto const files = prepare_input_files(
         options.input_files, options.input_format, options.append);
@@ -57,9 +57,14 @@ file_info run(options_t const &options, properties_t const &properties)
     middle->start();
 
     auto output = output_t::create_output(middle->get_query_instance(),
-                                          thread_pool, options, properties);
+                                          thread_pool, options, *properties);
 
     middle->set_requirements(output->get_requirements());
+
+    if (!options.append) {
+        properties->init_table();
+    }
+    properties->store();
 
     osmdata_t osmdata{middle, output, options};
 
@@ -93,8 +98,8 @@ void check_db(options_t const &options)
     check_schema(options.output_dbschema);
 }
 
-// This is called in "create" mode to store properties into the database.
-void store_properties(properties_t *properties, options_t const &options)
+// This is called in "create" mode to initialize properties.
+void set_up_properties(properties_t *properties, options_t const &options)
 {
     properties->set_bool("attributes", options.extra_attributes);
 
@@ -121,8 +126,6 @@ void store_properties(properties_t *properties, options_t const &options)
             std::filesystem::absolute(std::filesystem::path{options.style})
                 .string());
     }
-
-    properties->store();
 }
 
 void store_data_properties(properties_t *properties, file_info const &finfo)
@@ -139,8 +142,6 @@ void store_data_properties(properties_t *properties, file_info const &finfo)
             properties->set_string("replication_" + s, value);
         }
     }
-
-    properties->store();
 }
 
 void check_updatable(properties_t const &properties)
@@ -348,6 +349,7 @@ int main(int argc, char *argv[])
 
         properties_t properties{options.connection_params,
                                 options.middle_dbschema};
+
         if (options.append) {
             if (!properties.load()) {
                 throw std::runtime_error{
@@ -358,7 +360,7 @@ int main(int argc, char *argv[])
             check_and_update_properties(&properties, &options);
             properties.store();
 
-            auto const finfo = run(options, properties);
+            auto const finfo = run(options, &properties);
 
             if (finfo.last_timestamp.valid()) {
                 auto const current_timestamp =
@@ -369,16 +371,16 @@ int main(int argc, char *argv[])
                      osmium::Timestamp{current_timestamp})) {
                     properties.set_string("current_timestamp",
                                           finfo.last_timestamp.to_iso());
-                    properties.store();
                 }
             }
         } else {
-            properties.init_table();
             set_option_defaults(&options);
-            store_properties(&properties, options);
-            auto const finfo = run(options, properties);
+            set_up_properties(&properties, options);
+            auto const finfo = run(options, &properties);
             store_data_properties(&properties, finfo);
         }
+
+        properties.store();
 
         show_memory_usage();
         log_info("osm2pgsql took {} overall.",

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -206,7 +206,7 @@ void check_and_update_flat_node_file(properties_t *properties,
                 "Using the flat node file you specified on the command line"
                 " ('{}') instead of the one used on import ('{}').",
                 absolute_path, flat_node_file_from_import);
-            properties->set_string("flat_node_file", absolute_path, true);
+            properties->set_string("flat_node_file", absolute_path);
         }
     }
 }
@@ -291,7 +291,7 @@ void check_and_update_style_file(properties_t *properties, options_t *options)
     log_info("Using the style file you specified on the command line"
              " ('{}') instead of the one used on import ('{}').",
              absolute_path, style_file_from_import);
-    properties->set_string("style", absolute_path, true);
+    properties->set_string("style", absolute_path);
 }
 
 // This is called in "append" mode to check that the command line options are
@@ -356,6 +356,7 @@ int main(int argc, char *argv[])
             }
 
             check_and_update_properties(&properties, &options);
+            properties.store();
 
             auto const finfo = run(options, properties);
 
@@ -367,10 +368,12 @@ int main(int argc, char *argv[])
                     (finfo.last_timestamp >
                      osmium::Timestamp{current_timestamp})) {
                     properties.set_string("current_timestamp",
-                                          finfo.last_timestamp.to_iso(), true);
+                                          finfo.last_timestamp.to_iso());
+                    properties.store();
                 }
             }
         } else {
+            properties.init_table();
             set_option_defaults(&options);
             store_properties(&properties, options);
             auto const finfo = run(options, properties);

--- a/src/properties.hpp
+++ b/src/properties.hpp
@@ -53,10 +53,8 @@ public:
      *
      * \param property Name of the property
      * \param value Value of the property
-     * \param update_database Update database with this value immediately.
      */
-    void set_string(std::string property, std::string value,
-                    bool update_database = false);
+    void set_string(std::string property, std::string value);
 
     /**
      * Set property to integer value. The integer will be converted to a string
@@ -64,10 +62,8 @@ public:
      *
      * \param property Name of the property
      * \param value Value of the property
-     * \param update_database Update database with this value immediately.
      */
-    void set_int(std::string property, int64_t value,
-                 bool update_database = false);
+    void set_int(std::string property, int64_t value);
 
     /**
      * Set property to boolean value. In the database this will show up as the
@@ -75,15 +71,18 @@ public:
      *
      * \param property Name of the property
      * \param value Value of the property
-     * \param update_database Update database with this value immediately.
      */
-    void set_bool(std::string property, bool value,
-                  bool update_database = false);
+    void set_bool(std::string property, bool value);
 
     /**
-     * Store all properties in the database. Creates the properties table in
-     * the database if needed. Removes any properties that might already be
-     * stored in the database.
+     * Initialize the database table 'osm2pgsql_properties'. It is created if
+     * it does not exist and truncated.
+     */
+    void init_table();
+
+    /**
+     * Store all properties in the database that changed since the last store.
+     * Overwrites any properties that might already be stored in the database.
      */
     void store();
 
@@ -102,7 +101,13 @@ public:
 private:
     std::string table_name() const;
 
+    // The properties
     std::map<std::string, std::string> m_properties;
+
+    // Temporary storage of all properties that need to be updated in the
+    // database.
+    std::map<std::string, std::string> m_to_update;
+
     connection_params_t m_connection_params;
     std::string m_schema;
     bool m_has_properties_table;


### PR DESCRIPTION
(Changes to) Properties are stored at a later time in the database so the db is not changed if osm2pgsql fails for some reason. Basically we are trying to do as many checks as possible before actually writing the properties to the db. For instance the input file is now actually opened before properties are written,

This solves some cases already mentioned in PR #2085. 