### PR TITLE
Simplify code showing timers in generalization code

### DIFF
--- a/src/gen/osm2pgsql-gen.cpp
+++ b/src/gen/osm2pgsql-gen.cpp
@@ -327,10 +327,9 @@ public:
 
         log_debug("Timers:");
         for (auto const &timer : generalizer->timers()) {
-            log_debug(fmt::format(
-                "  {:10} {:>10L}", timer.name() + ":",
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    timer.elapsed())));
+            log_debug("  {:10} {:>10L}", timer.name() + ":",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          timer.elapsed()));
         }
         log_info("Finished generalizer '{}' in {}.", generalizer->name(),
                  util::human_readable_duration(timer_gen.stop()));


### PR DESCRIPTION
No reason to use dynamically created format strings here.