### PR TITLE
Move pgsql deprecation check to right spot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "macos-12"
           - "macos-13"
           - "macos-14" # latest
     runs-on: ${{ matrix.os }}

--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -183,10 +183,6 @@ void check_options_output_null(CLI::App const &app)
 
 void check_options_output_pgsql(CLI::App const &app, options_t *options)
 {
-    log_warn("The pgsql (default) output is deprecated. For details see "
-             "https://osm2pgsql.org/doc/"
-             "faq.html#the-pgsql-output-is-deprecated-what-does-that-mean");
-
     if (app.count("--latlong") + app.count("--merc") + app.count("--proj") >
         1) {
         throw std::runtime_error{"You can only use one of --latlong, -l, "

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -442,6 +442,10 @@ output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
   m_rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes),
   m_area_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
+    log_warn("The pgsql (default) output is deprecated. For details see "
+             "https://osm2pgsql.org/doc/"
+             "faq.html#the-pgsql-output-is-deprecated-what-does-that-mean");
+
     m_expire_config.full_area_limit = get_options()->expire_tiles_max_bbox;
     if (get_options()->expire_tiles_max_bbox > 0.0) {
         m_expire_config.mode = expire_mode::hybrid;


### PR DESCRIPTION
The check was in the wrong position. When running updates the output is read from the osm2pgsql_properties table which only happened after the check, so you'd still see the message even if you are using the flex output.

Sorry about that.