### PR TITLE
Properly forward schema parameters from replication script

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -111,8 +111,8 @@ class DBError(Exception):
 
 class DBConnection:
 
-    def __init__(self, args):
-        self.schema = args.middle_schema
+    def __init__(self, schema, args):
+        self.schema = schema
 
         # If dbname looks like a conninfo string use it as such
         if args.database and any(part in args.database for part in ['=', '://']):
@@ -535,8 +535,10 @@ def update(props, args):
 
     osm2pgsql = [args.osm2pgsql_cmd, '--append', '--slim', '--prefix', args.prefix]
     osm2pgsql.extend(args.extra_params)
-    if args.middle_schema != 'public':
+    if args.middle_schema:
         osm2pgsql.extend(('--middle-schema', args.middle_schema))
+    if args.schema:
+        osm2pgsql.extend(('--schema', args.schema))
     if args.database:
         osm2pgsql.extend(('-d', args.database))
     if args.username:
@@ -717,16 +719,16 @@ def main(prog_args=None):
                         datefmt='%Y-%m-%d %H:%M:%S',
                         level=max(4 - args.verbose, 1) * 10)
 
-    args.middle_schema = args.middle_schema or args.schema or 'public'
+    prop_table_schema = args.middle_schema or args.schema or 'public'
 
-    with DBConnection(args) as db:
+    with DBConnection(prop_table_schema, args) as db:
         if db.table_exists(Osm2pgsqlProperties.PROP_TABLE_NAME):
             props = Osm2pgsqlProperties(db)
         else:
             props = LegacyProperties(db, args.prefix)
 
         if not props.is_updatable:
-            LOG.fatal(f'osm2pgsql middle table "{args.middle_schema}.{args.prefix}_ways" not found in database "{db.name}". '
+            LOG.fatal(f'osm2pgsql middle table "{prop_table_schema}.{args.prefix}_ways" not found in database "{db.name}". '
                        'Database needs to be imported in --slim mode.')
             return 1
 

--- a/tests/bdd/command-line/replication_schema.feature
+++ b/tests/bdd/command-line/replication_schema.feature
@@ -1,0 +1,68 @@
+Feature: Tests for the osm2pgsql-replication script with schemas
+
+    Scenario: Replication updates work on database with schema
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the database schema foobar
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim | --schema | foobar |
+        And running osm2pgsql-replication
+            | init | --schema | foobar |
+        And running osm2pgsql-replication
+            | update | --schema | foobar |
+
+        Then table foobar.osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000001                                        |
+            | replication_timestamp       | 2013-10-01T01:00:00Z                            |
+
+
+    Scenario: Replication updates work on database with different middle schema
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the database schema foobar
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim | --middle-schema | foobar |
+        And running osm2pgsql-replication
+            | init | --middle-schema | foobar |
+        And running osm2pgsql-replication
+            | update | --middle-schema | foobar |
+
+        Then table foobar.osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000001                                        |
+            | replication_timestamp       | 2013-10-01T01:00:00Z                            |
+
+
+    Scenario: Replication updates work on database with middle schema different from schema
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the database schema foobar
+        And the database schema baz
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim | --middle-schema | foobar | --schema | baz |
+        And running osm2pgsql-replication
+            | init | --middle-schema | foobar | --schema | baz |
+        And running osm2pgsql-replication
+            | update | --middle-schema | foobar | --schema | baz |
+
+        Then table foobar.osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000001                                        |
+            | replication_timestamp       | 2013-10-01T01:00:00Z                            |
+


### PR DESCRIPTION
`--schema` and `--middle-schema` are now forwarded as-is to osm2pgsql.

Fixes #2259.