### PR TITLE
Refactor: Use fmt builtin functionality to format variants

### DIFF
--- a/src/format.hpp
+++ b/src/format.hpp
@@ -12,6 +12,7 @@
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <stdexcept>
 

--- a/src/gen/params.cpp
+++ b/src/gen/params.cpp
@@ -14,15 +14,6 @@
 #include "overloaded.hpp"
 #include "pgsql.hpp"
 
-std::string to_string(param_value_t const &value)
-{
-    return std::visit(
-        overloaded{[](null_param_t) { return std::string{}; },
-                   [](std::string val) { return val; },
-                   [](auto const &val) { return fmt::to_string(val); }},
-        value);
-}
-
 param_value_t params_t::get(std::string const &key) const
 {
     return m_map.at(key);
@@ -58,7 +49,7 @@ double params_t::get_double(std::string const &key, double default_value) const
         return static_cast<double>(std::get<int64_t>(it->second));
     }
 
-    throw fmt_error("Invalid value '{}' for {}.", to_string(it->second), key);
+    throw fmt_error("Invalid value '{}' for {}.", it->second, key);
 }
 
 std::string params_t::get_string(std::string const &key) const
@@ -67,7 +58,7 @@ std::string params_t::get_string(std::string const &key) const
     if (it == m_map.end()) {
         throw fmt_error("Missing parameter '{}' on generalizer.", key);
     }
-    return to_string(it->second);
+    return fmt::format("{}", it->second);
 }
 
 std::string params_t::get_string(std::string const &key,
@@ -82,7 +73,7 @@ std::string params_t::get_identifier(std::string const &key) const
     if (it == m_map.end()) {
         return {};
     }
-    std::string result = to_string(it->second);
+    std::string result = fmt::format("{}", it->second);
     check_identifier(result, key.c_str());
     return result;
 }
@@ -94,7 +85,7 @@ void params_t::check_identifier_with_default(std::string const &key,
     if (it == m_map.end()) {
         m_map.emplace(key, std::move(default_value));
     } else {
-        check_identifier(to_string(it->second), key.c_str());
+        check_identifier(fmt::format("{}", it->second), key.c_str());
     }
 }
 
@@ -120,6 +111,6 @@ void write_to_debug_log(params_t const &params, char const *message)
     }
     log_debug("{}", message);
     for (auto const &[key, value] : params) {
-        log_debug("  {}={}", key, to_string(value));
+        log_debug("  {}={}", key, value);
     }
 }

--- a/src/gen/params.hpp
+++ b/src/gen/params.hpp
@@ -24,9 +24,6 @@ using null_param_t = std::monostate;
 using param_value_t =
     std::variant<null_param_t, std::string, int64_t, double, bool>;
 
-/// Convert a parameter value into a string.
-std::string to_string(param_value_t const &value);
-
 /**
  * A collection of parameters.
  */
@@ -79,8 +76,7 @@ private:
         }
 
         if (!std::holds_alternative<T>(it->second)) {
-            throw fmt_error("Invalid value '{}' for {}.", to_string(it->second),
-                            key);
+            throw fmt_error("Invalid value '{}' for {}.", it->second, key);
         }
         return std::get<T>(it->second);
     }

--- a/src/gen/template.cpp
+++ b/src/gen/template.cpp
@@ -11,7 +11,7 @@
 
 void template_t::set_params(params_t const &params) {
     for (auto const &[key, value] : params) {
-        m_format_store.push_back(fmt::arg(key.c_str(), to_string(value)));
+        m_format_store.push_back(fmt::arg(key.c_str(), value));
     }
 }
 


### PR DESCRIPTION
When including the fmt/std.h header the fmt library has support for formatting std::variant. So we don't need to do this ourselves.