### PR TITLE
Add option to create primary key on flex tables

### DIFF
--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -112,7 +112,10 @@ void parse_create_index(lua_State *lua_state, flex_table_t *table)
         table->set_always_build_id_index();
     } else if (create_index == "unique") {
         table->set_always_build_id_index();
-        table->set_build_unique_id_index();
+        table->set_build_unique_id_index(false);
+    } else if (create_index == "primary_key") {
+        table->set_always_build_id_index();
+        table->set_build_unique_id_index(true);
     } else if (create_index != "auto") {
         throw fmt_error("Unknown value '{}' for 'create_index' field of ids",
                         create_index);

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -223,6 +223,15 @@ std::string flex_table_t::build_sql_column_list() const
 
 std::string flex_table_t::build_sql_create_id_index() const
 {
+    if (m_primary_key_index) {
+        auto ts = tablespace_clause(index_tablespace());
+        if (!ts.empty()) {
+            ts = " USING INDEX" + ts;
+        }
+        return fmt::format("ALTER TABLE {} ADD PRIMARY KEY ({}){}", full_name(),
+                           id_column_names(), ts);
+    }
+
     return fmt::format("CREATE {}INDEX ON {} USING BTREE ({}) {}",
                        m_build_unique_id_index ? "UNIQUE " : "", full_name(),
                        id_column_names(),

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -194,9 +194,10 @@ public:
         return m_always_build_id_index;
     }
 
-    void set_build_unique_id_index() noexcept
+    void set_build_unique_id_index(bool as_primary_key) noexcept
     {
         m_build_unique_id_index = true;
+        m_primary_key_index = as_primary_key;
     }
 
     bool build_unique_id_index() const noexcept
@@ -264,6 +265,9 @@ private:
 
     /// Build the index as a unique index.
     bool m_build_unique_id_index = false;
+
+    /// Index should be a primary key.
+    bool m_primary_key_index = false;
 
 }; // class flex_table_t
 

--- a/tests/bdd/flex/lua-table-definitions.feature
+++ b/tests/bdd/flex/lua-table-definitions.feature
@@ -99,6 +99,40 @@ Feature: Table definitions in Lua file
         When running osm2pgsql flex
         Then table foo has 1562 rows
 
+    Scenario: Unique index is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'foo',
+                ids = { type = 'node', id_column = 'node_id', index = 'unique' },
+                columns = {}
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table foo has 1562 rows
+
+    Scenario: Primary key is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'foo',
+                ids = { type = 'node', id_column = 'node_id', index = 'primary_key' },
+                columns = {}
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table foo has 1562 rows
+
     Scenario: Can not create two tables with the same name
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style


### PR DESCRIPTION
This is basically just a small variant of the option to create unique indexes. But it documents the intention that the specified columns is supposed to be the primary key. Some programs (like pg_featureserv) use this information to handle the primary key specially.