### PR TITLE
Actions: use OSGeo downloads for Postgis on Windows and enable windows-2025

### DIFF
--- a/.github/actions/win-postgres/action.yml
+++ b/.github/actions/win-postgres/action.yml
@@ -3,11 +3,38 @@ name: Set up PostgreSQL on Windows
 runs:
   using: composite
   steps:
+    - name: Decide Postgis version (Windows)
+      # Borrowed from https://github.com/nyurik/action-setup-postgis/blob/main/action.yml
+      id: postgis-ver
+      shell: pwsh
+      run: |
+        echo "PowerShell version: ${PSVersionTable.PSVersion}"
+        $PG_VERSION = Split-Path $env:PGROOT -Leaf
+        $postgis_page = "https://download.osgeo.org/postgis/windows/pg$PG_VERSION"
+        echo "Detecting PostGIS version from $postgis_page for PostgreSQL $PG_VERSION"
+        $pgis_bundle = (Invoke-WebRequest -Uri $postgis_page -ErrorAction Stop).Links.Where({$_.href -match "^postgis.*zip$"}).href
+        if (!$pgis_bundle) {
+          Write-Error "Could not find latest PostGIS version in $postgis_page that would match  ^postgis.*zip$  pattern"
+          exit 1
+        }
+        $pgis_bundle = [IO.Path]::ChangeExtension($pgis_bundle, [NullString]::Value)
+        $pgis_bundle_url = "$postgis_page/$pgis_bundle.zip"
+        Add-Content $env:GITHUB_OUTPUT "postgis_file=$pgis_bundle"
+        Add-Content $env:GITHUB_OUTPUT "postgis_bundle_url=$pgis_bundle_url"
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          C:/postgis.zip
+        key: postgis-cache-${{ steps.postgis-ver.outputs.postgis_file }}
+
     - name: Download postgis
       run: |
-        if (!(Test-Path "C:\postgis.zip")){(new-object net.webclient).DownloadFile("https://osm2pgsql.org/ci/winbuild/postgis-bundle-pg14-3.2.0x64.zip", "c:\postgis.zip")}
+        if (!(Test-Path "C:\postgis.zip")){(new-object net.webclient).DownloadFile($env:PGIS_BUNDLE_URL, "c:\postgis.zip")}
         7z x c:\postgis.zip -oc:\postgis_archive
       shell: pwsh
+      env:
+        PGIS_BUNDLE_URL: ${{ steps.postgis-ver.outputs.postgis_bundle_url }}
 
     - name: Install postgis
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2019, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -356,11 +356,6 @@ jobs:
           key: vcpkg-binary-cache-${{ matrix.os }}-${{ github.run_id }}
           restore-keys: |
             vcpkg-binary-cache-${{ matrix.os }}
-      - uses: actions/cache@v4
-        with:
-          path: |
-            C:/postgis.zip
-          key: postgis-cache
       - name: Prepare cache
         run: if [ ! -d C:/vcpkg_binary_cache ]; then mkdir C:/vcpkg_binary_cache; fi
         shell: bash
@@ -393,11 +388,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            C:/postgis.zip
-          key: postgis-cache
       - uses: actions/download-artifact@v4
         with:
           name: osm2pgsql-win64


### PR DESCRIPTION
Doesn't use nyurik's postgis action directly but simply borrows the part of the code that downloads the postgis bundle from OSGeo. This seems to work nicely with the existing workflow.

Fixes #2285.