### PR TITLE
Update Github Actions to newer Ubuntu versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,57 +4,17 @@ on: [ push, pull_request ]
 
 jobs:
 
-  ubuntu20-pg96-gcc10-jit:
-    runs-on: ubuntu-20.04
+  ubuntu22-pg11-gcc10-jit:
+    runs-on: ubuntu-22.04
 
     env:
       CC: gcc-10
       CXX: g++-10
-      EXTRA_FLAGS: -Wno-unused-but-set-parameter # workaround for GCC bug
       LUA_VERSION: 5.3
       LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 9.6
-      POSTGIS_VERSION: 2.5
-      BUILD_TYPE: Release
-      PSYCOPG: 2
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/linux-cmake
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu20-pg96-clang10-jit:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: clang-10
-      CXX: clang++-10
-      LUA_VERSION: 5.3
-      LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 9.6
-      POSTGIS_VERSION: 2.5
-      BUILD_TYPE: Release
-      PSYCOPG: 2
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/linux-cmake
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu20-pg10-gcc10:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-      EXTRA_FLAGS: -Wno-unused-but-set-parameter # workaround for GCC bug
-      LUA_VERSION: 5.3
-      LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 10
+      POSTGRESQL_VERSION: 11
       POSTGIS_VERSION: 3
-      BUILD_TYPE: Debug
+      BUILD_TYPE: Release
       PSYCOPG: 2
 
     steps:
@@ -63,55 +23,34 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-
-  ubuntu20-pg11-clang10:
-    runs-on: ubuntu-20.04
+  ubuntu22-pg11-clang13-jit:
+    runs-on: ubuntu-22.04
 
     env:
-      CC: clang-10
-      CXX: clang++-10
+      CC: clang-13
+      CXX: clang++-13
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: ON
+      POSTGRESQL_VERSION: 11
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Release
+      PSYCOPG: 2
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg11-gcc10:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: gcc-10
+      CXX: g++-10
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 11
-      POSTGIS_VERSION: 2.5
-      BUILD_TYPE: Debug
-      PSYCOPG: 2
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/linux-cmake
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu20-pg13-gcc10-jit:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: gcc-10
-      CXX: g++-10
-      LUA_VERSION: 5.3
-      LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 13
-      POSTGIS_VERSION: 2.5
-      BUILD_TYPE: Debug
-      PSYCOPG: 2
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/linux-cmake
-      - uses: ./.github/actions/build-and-test
-
-
-  ubuntu20-pg15-clang10-jit:
-    runs-on: ubuntu-20.04
-
-    env:
-      CC: clang-10
-      CXX: clang++-10
-      LUA_VERSION: 5.3
-      LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 15
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 2
@@ -122,15 +61,74 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu20-pg15-clang10-noproj:
-    runs-on: ubuntu-20.04
+
+  ubuntu22-pg11-clang13:
+    runs-on: ubuntu-22.04
 
     env:
-      CC: clang-10
-      CXX: clang++-10
+      CC: clang-13
+      CXX: clang++-13
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 15
+      POSTGRESQL_VERSION: 11
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Debug
+      PSYCOPG: 2
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg13-gcc11-jit:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: gcc-11
+      CXX: g++-11
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: ON
+      POSTGRESQL_VERSION: 13
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Debug
+      PSYCOPG: 2
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
+      - uses: ./.github/actions/build-and-test
+
+
+  ubuntu22-pg12-clang14-jit:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: clang-14
+      CXX: clang++-14
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: ON
+      POSTGRESQL_VERSION: 12
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Debug
+      PSYCOPG: 2
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/linux-cmake
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg12-clang15-noproj:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: clang-15
+      CXX: clang++-15
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 3
       WITH_PROJ: OFF
       BUILD_TYPE: Debug
@@ -142,12 +140,12 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu20-pg16-clang10:
-    runs-on: ubuntu-20.04
+  ubuntu22-pg16-clang15:
+    runs-on: ubuntu-22.04
 
     env:
-      CC: clang-10
-      CXX: clang++-10
+      CC: clang-15
+      CXX: clang++-15
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 16
@@ -161,16 +159,17 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu20-pg13-gcc10-release:
-    runs-on: ubuntu-20.04
+  ubuntu22-pg13-gcc12-release:
+    runs-on: ubuntu-22.04
 
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-12
+      CXX: g++-12
+      EXTRA_FLAGS: -Wno-stringop-overread
       LUA_VERSION: 5.3
       LUAJIT_OPTION: ON
       POSTGRESQL_VERSION: 13
-      POSTGIS_VERSION: 2.5
+      POSTGIS_VERSION: 3
       BUILD_TYPE: Release
       PSYCOPG: 2
 
@@ -180,15 +179,15 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-clang14-jit:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg14-clang16-jit:
+    runs-on: ubuntu-24.04
 
     env:
-      CC: clang-14
-      CXX: clang++-14
+      CC: clang-16
+      CXX: clang++-16
       LUA_VERSION: 5.4
       LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 16
+      POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 2
@@ -199,15 +198,15 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-clang14-proj:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg14-clang17-proj:
+    runs-on: ubuntu-24.04
 
     env:
-      CC: clang-14
-      CXX: clang++-14
+      CC: clang-17
+      CXX: clang++-17
       LUA_VERSION: 5.4
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 16
+      POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 2
@@ -218,15 +217,15 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-clang14-noproj:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg15-clang17-noproj:
+    runs-on: ubuntu-24.04
 
     env:
-      CC: clang-14
-      CXX: clang++-14
+      CC: clang-17
+      CXX: clang++-17
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 16
+      POSTGRESQL_VERSION: 15
       POSTGIS_VERSION: 3
       WITH_PROJ: OFF
       BUILD_TYPE: Debug
@@ -238,12 +237,12 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg15-clang14:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg15-clang18:
+    runs-on: ubuntu-24.04
 
     env:
-      CC: clang-14
-      CXX: clang++-14
+      CC: clang-18
+      CXX: clang++-18
       LUA_VERSION: 5.4
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 15
@@ -257,8 +256,8 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-gcc12-release:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg16-gcc12-release:
+    runs-on: ubuntu-24.04
 
     env:
       CC: gcc-12
@@ -277,15 +276,15 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-clang15-cpp20:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg17-clang16-cpp20:
+    runs-on: ubuntu-24.04
 
     env:
-      CC: clang-15
-      CXX: clang++-15
+      CC: clang-16
+      CXX: clang++-16
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 16
+      POSTGRESQL_VERSION: 17
       POSTGIS_VERSION: 3
       CPP_VERSION: 20
       BUILD_TYPE: Debug
@@ -297,39 +296,19 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg16-gcc12-cpp20:
-    runs-on: ubuntu-22.04
+  ubuntu24-pg17-gcc12-cpp20:
+    runs-on: ubuntu-24.04
 
     env:
       CC: gcc-12
       CXX: g++-12
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 16
+      POSTGRESQL_VERSION: 17
       POSTGIS_VERSION: 3
       CPP_VERSION: 20
       BUILD_TYPE: Debug
       PSYCOPG: 3
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/linux-cmake
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu24-pg16-gcc14:
-    runs-on: ubuntu-24.04
-
-    env:
-      CC: gcc-14
-      CXX: g++-14
-      LUA_VERSION: 5.4
-      LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 16
-      POSTGIS_VERSION: 3
-      BUILD_TYPE: Debug
-      PSYCOPG: 3
-      PIP_OPTION: --break-system-packages
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   ubuntu-test-install:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -19,7 +19,7 @@ jobs:
 
     env:
       LUA_VERSION: 5.3
-      POSTGRESQL_VERSION: 14
+      POSTGRESQL_VERSION: 16
       POSTGIS_VERSION: 3
       BUILD_TYPE: Release
       CXXFLAGS: -pedantic -Wextra -Wno-stringop-overread -Werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,10 @@ if (NOT WIN32 AND NOT APPLE)
     set(PostgreSQL_TYPE_INCLUDE_DIR /usr/include)
 endif()
 
-set(MINIMUM_POSTGRESQL_SERVER_VERSION "9.6")
-set(MINIMUM_POSTGRESQL_SERVER_VERSION_NUM "90600")
+set(MINIMUM_POSTGRESQL_SERVER_VERSION "11")
+set(MINIMUM_POSTGRESQL_SERVER_VERSION_NUM "110000")
 
-set(PostgreSQL_ADDITIONAL_VERSIONS "17" "16" "15" "14" "13" "12" "11" "10" "9.6")
+set(PostgreSQL_ADDITIONAL_VERSIONS "17" "16" "15" "14" "13" "12" "11")
 
 #############################################################
 # Version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(osm2pgsql VERSION 2.0.1 LANGUAGES CXX C)
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ with other versions of those libraries (set the `EXTERNAL_*libname*` option to
 * [protozero](https://github.com/mapbox/protozero) (>= 1.6.3)
 
 It also requires access to a database server running
-[PostgreSQL](https://www.postgresql.org/) (version 9.6+ works, 13+ strongly
-recommended) and [PostGIS](https://www.postgis.net/) (version 2.5+).
+[PostgreSQL](https://www.postgresql.org/) (version 11+ works, 13+ strongly
+recommended) and [PostGIS](https://www.postgis.net/) (version 3.0+).
 
 Make sure you have installed the development packages for the libraries
 mentioned in the requirements section and a C++ compiler which supports C++17.
-We officially support gcc >= 8.0 and clang >= 8.
+We officially support gcc >= 10.0 and clang >= 13.
 
 To rebuild the included man page you'll need the [pandoc](https://pandoc.org/)
 tool.

--- a/src/flex-lua-index.cpp
+++ b/src/flex-lua-index.cpp
@@ -105,23 +105,17 @@ void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
     // get include columns
     std::vector<std::string> include_columns;
     lua_getfield(lua_state, -1, "include");
-    if (get_database_version() >= 110000) {
-        if (lua_isstring(lua_state, -1)) {
-            check_and_add_column(*table, &include_columns,
-                                 lua_tostring(lua_state, -1));
-        } else if (lua_istable(lua_state, -1)) {
-            check_and_add_columns(*table, &include_columns, lua_state);
-        } else if (!lua_isnil(lua_state, -1)) {
-            throw std::runtime_error{
-                "The 'include' field in an index definition must contain a "
-                "string or an array."};
-        }
-        index.set_include_columns(include_columns);
+    if (lua_isstring(lua_state, -1)) {
+        check_and_add_column(*table, &include_columns,
+                             lua_tostring(lua_state, -1));
+    } else if (lua_istable(lua_state, -1)) {
+        check_and_add_columns(*table, &include_columns, lua_state);
     } else if (!lua_isnil(lua_state, -1)) {
-        throw fmt_error("Database version ({}) doesn't support"
-                        " include columns in indexes.",
-                        get_database_version());
+        throw std::runtime_error{
+            "The 'include' field in an index definition must contain a "
+            "string or an array."};
     }
+    index.set_include_columns(include_columns);
     lua_pop(lua_state, 1);
 
     // get tablespace

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -89,8 +89,8 @@ void check_db(options_t const &options)
     init_database_capabilities(db_connection);
 
     auto const pv = get_postgis_version();
-    if (pv.major < 2 || (pv.major == 2 && pv.minor < 5)) {
-        throw std::runtime_error{"Need at least PostGIS version 2.5"};
+    if (pv.major < 3) {
+        throw std::runtime_error{"Need at least PostGIS version 3.0"};
     }
 
     check_schema(options.dbschema);


### PR DESCRIPTION
Github Actions will pull the Ubuntu 20.04 images beginning of April, so it's time to update our test images to newer versions. This moves all tests previously done in 20.04 to 22.04 and the ones that already were on 22.04 to 24.04.

There are a couple of software versions we cannot test anymore, so they go out of support. New minimum supported versions are:

* PostgreSQL 11+
* PostGIS 3.0+
* gcc 10+
* clang 13+

Also updates minimum version of cmake to 3.10 because more recent cmake versions complain otherwise.