### PR TITLE
github actions: fix setup of PostgreSQL

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -6,10 +6,8 @@ runs:
   steps:
     - name: Remove preinstalled PostgreSQL
       run: |
-        sudo apt-get remove -yq postgresql*
-        sudo apt-get install curl ca-certificates gnupg
-        curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
-        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+        sudo apt-get purge -yq postgresql*
         sudo apt-get update -qq
       shell: bash
 

--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -30,7 +30,6 @@ runs:
           python3-setuptools \
           zlib1g-dev
         pip3 install $PIP_OPTION behave osmium
-        if [ "$CC" = clang-8 ]; then sudo apt-get install -yq --no-install-suggests --no-install-recommends clang-8; fi
         if [ "$PSYCOPG" = "2"]; then
             sudo apt-get install -yq --no-install-suggests --no-install-recommends python3-psycopg2
         else


### PR DESCRIPTION
Postgresql's apt repository has slightly changed the setup rules for its postgres packages in Thursday's release: normally the package would automatically set up and start a database, if not exists for the version installed. The new behaviour seems to be to only set up the database if there is no Postgresql database set up at all. This new behaviour makes perfect sense, but breaks CI runs which so far have kept the already installed postgres from the default version around. The version we actually want to test against is not installed anymore. The fix is to purge the default version instead of just removing it.

The PR also switches to the Debian-supplied way of setting up the PostgreSQL apt repository and removes some code for a clang version which has long fallen out of support.