### PR TITLE
Remove comment that doesn't apply any more

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -88,9 +88,6 @@ void db_deleter_by_type_and_id_t::delete_rows(std::string const &table,
 
 db_copy_thread_t::db_copy_thread_t(connection_params_t const &connection_params)
 {
-    // Connection params are captured by copy here, because we don't know
-    // whether the reference will still be valid once we get around to running
-    // the thread.
     m_worker =
         std::thread{thread_t{pg_conn_t{connection_params, "copy"}, &m_shared}};
 }


### PR DESCRIPTION
In 6bd67a749d890a092557c8812fd67c0d3f170dce we changed the code to not copy the connection parameters but the connection.