### PR TITLE
Fix table:insert for tables without an id column

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -76,8 +76,9 @@ bool flex_table_t::has_id_column() const noexcept
 
 bool flex_table_t::matches_type(osmium::item_type type) const noexcept
 {
-    // This table takes any type -> okay
-    if (m_id_type == flex_table_index_type::any_object) {
+    // This table takes any type or has no ids -> okay
+    if (m_id_type == flex_table_index_type::any_object ||
+        m_id_type == flex_table_index_type::no_index) {
         return true;
     }
 

--- a/tests/bdd/flex/table-ids.feature
+++ b/tests/bdd/flex/table-ids.feature
@@ -1,0 +1,57 @@
+Feature: Test for correct id column generation
+
+    Background:
+        Given the 0.1 grid
+           | 1 |   |  2 |
+           | 3 |   |  4 |
+
+    Scenario: Data can be inserted into tables without an iD column
+        Given the lua style
+            """
+            local simple = osm2pgsql.define_table{
+                name = 'simple',
+                columns = {{ column = 'id', type = 'bigint'}}
+            }
+
+            function osm2pgsql.process_node(object)
+                simple:insert{ id = object.id }
+            end
+
+            function osm2pgsql.process_way(object)
+                simple:insert{ id = object.id }
+            end
+
+            function osm2pgsql.process_relation(object)
+                simple:insert{ id = object.id }
+            end
+            """
+        And the OSM data
+            """
+            n1 Tp=1
+            n2 Tp=2
+            w10 Tp=10 Nn1,n2,n4
+            r100 Tp=100 Mn1@,n2@
+            """
+        When running osm2pgsql flex with parameters
+            | --slim |
+        Then table simple contains
+            | id  |
+            | 1   |
+            | 2   |
+            | 10  |
+            | 100 |
+        Given the OSM data
+            """
+            n1 v2 dD
+            w11 Tp=11 Nn1,n3
+            """
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+        Then table simple contains
+            | id  |
+            | 1   |
+            | 2   |
+            | 10  |
+            | 11  |
+            | 100 |
+

--- a/tests/bdd/steps/geometry_factory.py
+++ b/tests/bdd/steps/geometry_factory.py
@@ -104,7 +104,7 @@ class GeometryFactory:
                 assert ' y' not in line
 
                 coords = self.grid_node(nid)
-                assert coords is not None, f"Coordinates missing for node {node}"
+                assert coords is not None, f"Coordinates missing for node {nid}"
                 nodes[i] = f"{line} x{coords[0]:.{self.grid_precision}f} y{coords[1]:.{self.grid_precision}f}"
 
             todos.discard(nid)


### PR DESCRIPTION
Trying to insert anything into a table that has no id column defined currently fails with:

```
Error in 'insert': Trying to add node to table 'foo'
```

That's because we have added sanity checks to match the currently handled object type to the table. The check used to let id-less tables pass until a6d6ab1a4cd1253e997c239df9fdfd8e7d974b1c added a special enum type for id types which distinguishes between "any" and "no_index" id columns.