### PR TITLE
Fix/disable some warnings generated by clang-tidy

### DIFF
--- a/src/geom-functions.cpp
+++ b/src/geom-functions.cpp
@@ -125,6 +125,7 @@ namespace {
 
 void set_to_same_type(geometry_t *output, geometry_t const &input)
 {
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     input.visit([&](auto in) { output->set<decltype(in)>(); });
 }
 
@@ -434,7 +435,7 @@ public:
     {}
 
     template <typename T>
-    void operator()(T) const
+    void operator()(T const &) const
     {}
 
     // false positive https://github.com/llvm/llvm-project/issues/74738
@@ -544,8 +545,9 @@ namespace {
  * empty, do not add the first point returned by *it.
  */
 template <typename ITERATOR>
-void add_nodes_to_linestring(linestring_t *linestring, ITERATOR it,
-                             ITERATOR end)
+void add_nodes_to_linestring(
+    linestring_t *linestring, ITERATOR it,
+    ITERATOR end) // NOLINT(performance-unnecessary-value-param)
 {
     if (!linestring->empty()) {
         assert(it != end);

--- a/src/wildcmp.cpp
+++ b/src/wildcmp.cpp
@@ -19,6 +19,7 @@
  *
  * Returns if a match was found.
  */
+// NOLINTNEXTLINE(misc-use-internal-linkage) Seems there is a bug in the checker
 bool wild_match(char const *expr, char const *str) noexcept
 {
     // Code based on


### PR DESCRIPTION
See individual commits.