### PR TITLE
Refactor: Split out some code from output_flex_t class

### DIFF
--- a/src/flex-lua-expire-output.hpp
+++ b/src/flex-lua-expire-output.hpp
@@ -10,10 +10,12 @@
  * For a full list of authors see the git log.
  */
 
-#include "expire-output.hpp"
+#include "flex-lua-wrapper.hpp"
 
+#include <string>
 #include <vector>
 
+class expire_output_t;
 struct lua_State;
 
 static char const *const osm2pgsql_expire_output_name =
@@ -22,5 +24,25 @@ static char const *const osm2pgsql_expire_output_name =
 int setup_flex_expire_output(lua_State *lua_state,
                              std::string const &default_schema,
                              std::vector<expire_output_t> *expire_outputs);
+
+class lua_wrapper_expire_output : public lua_wrapper_base<expire_output_t>
+{
+public:
+    static void init(lua_State *lua_state);
+
+    lua_wrapper_expire_output(lua_State *lua_state,
+                              expire_output_t *expire_output)
+    : lua_wrapper_base(lua_state, expire_output)
+    {
+    }
+
+    int __tostring() const;
+    int filename() const;
+    int maxzoom() const;
+    int minzoom() const;
+    int schema() const;
+    int table() const;
+
+}; // class lua_wrapper_expire_output
 
 #endif // OSM2PGSQL_FLEX_LUA_EXPIRE_OUTPUT_HPP

--- a/src/flex-lua-table.hpp
+++ b/src/flex-lua-table.hpp
@@ -10,6 +10,8 @@
  * For a full list of authors see the git log.
  */
 
+#include "flex-lua-wrapper.hpp"
+
 #include <string>
 #include <vector>
 
@@ -23,5 +25,23 @@ int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
                      std::vector<expire_output_t> *expire_outputs,
                      std::string const &default_schema, bool updatable,
                      bool append_mode);
+
+class lua_wrapper_table : public lua_wrapper_base<flex_table_t>
+{
+public:
+    static void init(lua_State *lua_state);
+
+    lua_wrapper_table(lua_State *lua_state, flex_table_t *table)
+    : lua_wrapper_base(lua_state, table)
+    {
+    }
+
+    int __tostring() const;
+    int cluster() const;
+    int columns() const;
+    int name() const;
+    int schema() const;
+
+}; // class lua_wrapper_table
 
 #endif // OSM2PGSQL_FLEX_LUA_TABLE_HPP

--- a/src/flex-lua-wrapper.hpp
+++ b/src/flex-lua-wrapper.hpp
@@ -1,0 +1,60 @@
+#ifndef OSM2PGSQL_FLEX_LUA_WRAPPER_HPP
+#define OSM2PGSQL_FLEX_LUA_WRAPPER_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2025 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "output-flex.hpp"
+
+#include <exception>
+
+#define TRAMPOLINE_WRAPPED_OBJECT(obj_name, func_name)                         \
+    int lua_trampoline_##obj_name##_##func_name(lua_State *lua_state)          \
+    {                                                                          \
+        try {                                                                  \
+            auto *flex =                                                       \
+                static_cast<output_flex_t *>(luaX_get_context(lua_state));     \
+            auto &obj = flex->get_##obj_name##_from_param();                   \
+            return lua_wrapper_##obj_name{lua_state, &obj}.func_name();        \
+        } catch (std::exception const &e) {                                    \
+            return luaL_error(lua_state, "Error in '" #func_name "': %s\n",    \
+                              e.what());                                       \
+        } catch (...) {                                                        \
+            return luaL_error(lua_state,                                       \
+                              "Unknown error in '" #func_name "'.\n");         \
+        }                                                                      \
+    }
+
+struct lua_State;
+
+/**
+ * Helper class for wrapping C++ classes in Lua "classes".
+ */
+template <typename WRAPPED>
+class lua_wrapper_base
+{
+public:
+    lua_wrapper_base(lua_State *lua_state, WRAPPED *wrapped)
+    : m_lua_state(lua_state), m_self(wrapped)
+    {
+    }
+
+protected:
+    lua_State *lua_state() const noexcept { return m_lua_state; }
+
+    WRAPPED const &self() const noexcept { return *m_self; }
+    WRAPPED &self() noexcept { return *m_self; }
+
+private:
+    lua_State *m_lua_state;
+    WRAPPED *m_self;
+
+}; // class lua_wrapper_base;
+
+#endif // OSM2PGSQL_FLEX_LUA_WRAPPER_HPP

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -164,20 +164,13 @@ public:
     int app_define_expire_output();
     int app_get_bbox();
 
-    int table_tostring();
     int table_insert();
-    int table_name();
-    int table_schema();
-    int table_cluster();
-    int table_columns();
 
-    int expire_output_tostring();
-    int expire_output_name();
-    int expire_output_minzoom();
-    int expire_output_maxzoom();
-    int expire_output_filename();
-    int expire_output_schema();
-    int expire_output_table();
+    // Get the flex table that is as first parameter on the Lua stack.
+    flex_table_t &get_table_from_param();
+
+    // Get the expire output that is as first parameter on the Lua stack.
+    expire_output_t &get_expire_output_from_param();
 
 private:
     void select_relation_members();
@@ -199,12 +192,6 @@ private:
                                          osmium::OSMObject const &object);
 
     void init_lua(std::string const &filename, properties_t const &properties);
-
-    // Get the flex table that is as first parameter on the Lua stack.
-    flex_table_t const &get_table_from_param();
-
-    // Get the expire output that is as first parameter on the Lua stack.
-    expire_output_t const &get_expire_output_from_param();
 
     void check_context_and_state(char const *name, char const *context,
                                  bool condition);
@@ -323,5 +310,7 @@ private:
      */
     bool m_disable_insert = false;
 };
+
+int lua_trampoline_table_insert(lua_State *lua_state);
 
 #endif // OSM2PGSQL_OUTPUT_FLEX_HPP


### PR DESCRIPTION
The class output_flex_t is huge, output-flex.cpp with over 1000 lines is the largest source code file we have. This change moves some code out of there.

This change introduces a new templated wrapper base class (lua_wrapper_base) for wrapping C++ objects in Lua. It is then used for the "Table" and "ExpireOutput" Lua objects. Functions that are called from Lua on those objects are called through the wrapper on the underlying C++ objects using little wrapper functions in the wrapper classes. A new macro TRAMPOLINE_WRAPPED_OBJECT() is used to call these functions where we used the TRAMPOLINE() macro before.

One problem is though that more complex functions need more of the machinery in the output_flex_t class to work, specifically this is the "insert" function for tables which can not be implemented without full access to the output_flex_t class. So this function keeps using the old mechanism.

This also changes the get_from_idx_param() helper function and the functions using it
(output_flex_t::[get_table|expire_output]_from_param()) to return a reference instead of a const reference so that the wrapper will be initialized with a mutable pointer to the underlying C++ class. Currently all functions that can be called through the wrapper are const functions, but this will not necessarily always be the case in the future.