### PR TITLE
Don't mention the Lua inspect library any more in example configs

### DIFF
--- a/flex-config/README.md
+++ b/flex-config/README.md
@@ -52,18 +52,6 @@ and when you need that functionality.
 The subdirectory [gen](gen/) contains example configurations for
 generalization support.
 
-## Dependencies
-
-Some of the example files use the `inspect` Lua library to show debugging
-output. It is not needed for the actual functionality of the examples, so if
-you don't have the library, you can remove all uses of `inspect` and the
-scripts should still work.
-
-The library is available from [the
-source](https://github.com/kikito/inspect.lua) or using
-[LuaRocks](https://luarocks.org/modules/kikito/inspect). Debian/Ubuntu users
-can install the `lua-inspect` package.
-
 ## Public Domain
 
 All the example config files in this directory are released into the Public

--- a/flex-config/simple.lua
+++ b/flex-config/simple.lua
@@ -5,9 +5,6 @@
 -- configuration. After reading and understanding this, have a look at
 -- "geometries.lua".
 
--- For debugging
--- inspect = require('inspect')
-
 -- The global variable "osm2pgsql" is used to talk to the main osm2pgsql code.
 -- You can, for instance, get the version of osm2pgsql:
 print('osm2pgsql version: ' .. osm2pgsql.version)
@@ -66,7 +63,6 @@ tables.polygons = osm2pgsql.define_area_table('polygons', {
 for name, dtable in pairs(tables) do
     print("\ntable '" .. name .. "':")
     print("  name='" .. dtable:name() .. "'")
---    print("  columns=" .. inspect(dtable:columns()))
 end
 
 -- Helper function to remove some of the tags we usually are not interested in.
@@ -84,9 +80,6 @@ end
 -- attributes of the node like `id`, `version`, etc. as well as all tags as a
 -- Lua table (`object.tags`).
 function osm2pgsql.process_node(object)
-    --  Uncomment next line to look at the object data:
-    --  print(inspect(object))
-
     if clean_tags(object.tags) then
         return
     end
@@ -114,9 +107,6 @@ end
 -- information as with nodes and additionally a boolean `is_closed` flag and
 -- the list of node IDs referenced by the way (`object.nodes`).
 function osm2pgsql.process_way(object)
-    --  Uncomment next line to look at the object data:
-    --  print(inspect(object))
-
     if clean_tags(object.tags) then
         return
     end
@@ -141,9 +131,6 @@ end
 -- same information as with nodes and additionally an array of members
 -- (`object.members`).
 function osm2pgsql.process_relation(object)
-    --  Uncomment next line to look at the object data:
-    --  print(inspect(object))
-
     if clean_tags(object.tags) then
         return
     end

--- a/flex-config/unitable.lua
+++ b/flex-config/unitable.lua
@@ -2,8 +2,6 @@
 
 -- Put all OSM data into a single table
 
--- inspect = require('inspect')
-
 -- We define a single table that can take any OSM object and any geometry.
 -- OSM nodes are converted to Points, ways to LineStrings and relations
 -- to GeometryCollections. If an object would create an invalid geometry
@@ -20,8 +18,6 @@ local dtable = osm2pgsql.define_table{
         { column = 'geom',  type = 'geometry' },
     }
 }
-
--- print("columns=" .. inspect(dtable:columns()))
 
 -- Helper function to remove some of the tags we usually are not interested in.
 -- Returns true if there are no tags left.


### PR DESCRIPTION
It is probably more confusing than useful here for the beginner. I have added something about the library to the manual instead.