### PR TITLE
Flex example configs

### DIFF
--- a/flex-config/attributes.lua
+++ b/flex-config/attributes.lua
@@ -1,10 +1,9 @@
 -- This config example file is released into the Public Domain.
 
 -- This config shows how to access the attributes of OSM objects: the version,
--- changeset id, timestamp, user id and user name. For this to work the
--- command line option --extra-attributes/-x must be set, otherwise those
--- fields will be empty. Also note that some OSM files do not contain all
--- of those attributes, so check your input data if you get empty fields.
+-- changeset id, timestamp, user id and user name. Note that some OSM files do
+-- not contain all of those attributes, so check your input data if you get
+-- empty fields.
 
 -- Set this to the projection you want to use
 local srid = 4326

--- a/flex-config/bbox.lua
+++ b/flex-config/bbox.lua
@@ -30,17 +30,6 @@ tables.boundaries = osm2pgsql.define_relation_table('boundaries', {
     { column = 'geom', type = 'multilinestring' },
 })
 
--- Helper function to remove some of the tags we usually are not interested in.
--- Returns true if there are no tags left.
-local function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
-
 -- Helper function that looks at the tags and decides if this is possibly
 -- an area.
 local function has_area_tags(tags)
@@ -91,10 +80,6 @@ local function format_bbox(object)
 end
 
 function osm2pgsql.process_node(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     tables.pois:insert({
         tags = object.tags,
         bbox = format_bbox(object),
@@ -103,10 +88,6 @@ function osm2pgsql.process_node(object)
 end
 
 function osm2pgsql.process_way(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     -- A closed way that also has the right tags for an area is a polygon.
     if object.is_closed and has_area_tags(object.tags) then
         tables.polygons:insert({
@@ -124,10 +105,6 @@ function osm2pgsql.process_way(object)
 end
 
 function osm2pgsql.process_relation(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     local relation_type = object:grab_tag('type')
 
     -- Store boundary relations as multilinestrings

--- a/flex-config/data-types.lua
+++ b/flex-config/data-types.lua
@@ -5,31 +5,33 @@
 -- at this file. This file demonstrates some column data type options.
 
 local highways = osm2pgsql.define_way_table('highways', {
-    { column = 'name',     type = 'text' },
+    { column = 'name', type = 'text' },
     -- We always need a highway type, so we can declare the column as NOT NULL
-    { column = 'type',     type = 'text', not_null = true },
+    { column = 'type', type = 'text', not_null = true },
 
     -- Add a SERIAL column and tell osm2pgsql not to fill it (PostgreSQL will
     -- do that for us)
-    { column = 'id',       sql_type = 'serial', create_only = true },
+    { column = 'id', sql_type = 'serial', create_only = true },
 
     -- type "direction" is special, see below
-    { column = 'oneway',   type = 'direction' },
+    { column = 'oneway', type = 'direction' },
     { column = 'maxspeed', type = 'int' },
 
     -- type "bool" is special, see below
-    { column = 'lit',      type = 'bool' },
-    { column = 'tags',     type = 'jsonb' }, -- also available: 'json', 'hstore'
+    { column = 'lit', type = 'bool' },
+    { column = 'tags', type = 'jsonb' }, -- also available: 'json', 'hstore'
 
     -- osm2pgsql doesn't know about PostgreSQL arrays, so we define the SQL
     -- type of this column and then have to convert our array data into a
     -- valid text representation for that type, see below.
-    { column = 'nodes',    sql_type = 'int8[]' },
-    { column = 'geom',     type = 'linestring' },
+    { column = 'nodes', sql_type = 'int8[]' },
+    { column = 'geom', type = 'linestring' },
 })
 
 -- Helper function to remove some of the tags we usually are not interested in.
--- Returns true if there are no tags left.
+-- Something like this can be useful if you are writing all tags to the
+-- database in a JSON(B) column and don't want that cluttered with lots of tags
+-- nobody cares about. Returns true if there are no tags left.
 local function clean_tags(tags)
     tags.odbl = nil
     tags.created_by = nil

--- a/flex-config/expire.lua
+++ b/flex-config/expire.lua
@@ -45,7 +45,9 @@ tables.pois = osm2pgsql.define_node_table('pois', {
     -- Zero, one or more expire outputs are referenced in an `expire` field in
     -- the definition of any geometry column using the Web Mercator (3857)
     -- projection.
-    { column = 'geom', type = 'point', not_null = true, expire = { { output = expire_outputs.pois } } },
+    { column = 'geom', type = 'point', not_null = true, expire = {
+        { output = expire_outputs.pois }
+    }},
 })
 
 tables.lines = osm2pgsql.define_way_table('lines', {

--- a/flex-config/geometries.lua
+++ b/flex-config/geometries.lua
@@ -55,17 +55,6 @@ tables.pubs = osm2pgsql.define_node_table('pubs', {
     { column = 'name', type = 'text' }
 })
 
--- Helper function to remove some of the tags we usually are not interested in.
--- Returns true if there are no tags left.
-local function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
-
 -- Helper function that looks at the tags and decides if this is possibly
 -- an area.
 local function has_area_tags(tags)
@@ -105,10 +94,6 @@ local function has_area_tags(tags)
 end
 
 function osm2pgsql.process_node(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     local geom = object:as_point()
 
     tables.pois:insert({
@@ -124,10 +109,6 @@ function osm2pgsql.process_node(object)
 end
 
 function osm2pgsql.process_way(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     -- A closed way that also has the right tags for an area is a polygon.
     if object.is_closed and has_area_tags(object.tags) then
         -- Creating the polygon geometry takes time, so we do it once here
@@ -166,10 +147,6 @@ function osm2pgsql.process_way(object)
 end
 
 function osm2pgsql.process_relation(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
     local relation_type = object:grab_tag('type')
 
     -- Store boundary relations as multilinestrings

--- a/flex-config/public-transport.lua
+++ b/flex-config/public-transport.lua
@@ -20,25 +20,25 @@
 local tables = {}
 
 tables.stops = osm2pgsql.define_node_table('stops', {
-    { column = 'tags',     type = 'jsonb' },
+    { column = 'tags', type = 'jsonb' },
     { column = 'rel_refs', type = 'text' }, -- for the refs from the relations
-    { column = 'rel_ids',  sql_type = 'int8[]' }, -- array with integers (for relation IDs)
-    { column = 'geom',     type = 'point', not_null = true },
+    { column = 'rel_ids', sql_type = 'int8[]' }, -- array with integers (for relation IDs)
+    { column = 'geom', type = 'point', not_null = true },
 })
 
 tables.lines = osm2pgsql.define_way_table('lines', {
-    { column = 'tags',     type = 'jsonb' },
+    { column = 'tags', type = 'jsonb' },
     { column = 'rel_refs', type = 'text' }, -- for the refs from the relations
-    { column = 'rel_ids',  sql_type = 'int8[]' }, -- array with integers (for relation IDs)
-    { column = 'geom',     type = 'linestring', not_null = true },
+    { column = 'rel_ids', sql_type = 'int8[]' }, -- array with integers (for relation IDs)
+    { column = 'geom', type = 'linestring', not_null = true },
 })
 
 -- Tables don't have to have a geometry column
 tables.routes = osm2pgsql.define_relation_table('routes', {
-    { column = 'ref',  type = 'text' },
+    { column = 'ref', type = 'text' },
     { column = 'type', type = 'text' },
     { column = 'from', type = 'text' },
-    { column = 'to',   type = 'text' },
+    { column = 'to', type = 'text' },
     { column = 'tags', type = 'jsonb' },
 })
 
@@ -46,9 +46,9 @@ tables.routes = osm2pgsql.define_relation_table('routes', {
 -- stop. We model them here by adding a center point as geometry plus the
 -- radius of a circle that contains everything in that stop.
 tables.stop_areas = osm2pgsql.define_relation_table('stop_areas', {
-    { column = 'tags',   type = 'jsonb' },
+    { column = 'tags', type = 'jsonb' },
     { column = 'radius', type = 'real', not_null = true },
-    { column = 'geom',   type = 'point', not_null = true },
+    { column = 'geom', type = 'point', not_null = true },
 })
 
 -- This will be used to store information about relations queryable by member
@@ -60,15 +60,6 @@ tables.stop_areas = osm2pgsql.define_relation_table('stop_areas', {
 -- result.
 local n2r = {}
 local w2r = {}
-
-local function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
 
 local function unique_array(array)
     local result = {}
@@ -127,8 +118,6 @@ function osm2pgsql.process_way(object)
     if not object.tags.highway and not object.tags.railway then
         return
     end
-
-    clean_tags(object.tags)
 
     -- Data we will store in the 'lines' table always has the tags from
     -- the way

--- a/flex-config/route-relations.lua
+++ b/flex-config/route-relations.lua
@@ -12,10 +12,10 @@
 local tables = {}
 
 tables.highways = osm2pgsql.define_way_table('highways', {
-    { column = 'tags',     type = 'jsonb' },
+    { column = 'tags', type = 'jsonb' },
     { column = 'rel_refs', type = 'text' }, -- for the refs from the relations
-    { column = 'rel_ids',  sql_type = 'int8[]' }, -- array with integers (for relation IDs)
-    { column = 'geom',     type = 'linestring', not_null = true },
+    { column = 'rel_ids', sql_type = 'int8[]' }, -- array with integers (for relation IDs)
+    { column = 'geom', type = 'linestring', not_null = true },
 })
 
 -- Tables don't have to have a geometry column
@@ -31,22 +31,11 @@ tables.routes = osm2pgsql.define_relation_table('routes', {
 -- it can be called any number of times and will lead to the same result.
 local w2r = {}
 
-local function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
-
 function osm2pgsql.process_way(object)
     -- We are only interested in highways
     if not object.tags.highway then
         return
     end
-
-    clean_tags(object.tags)
 
     -- Data we will store in the "highways" table always has the tags from
     -- the way

--- a/flex-config/unitable.lua
+++ b/flex-config/unitable.lua
@@ -6,7 +6,6 @@
 -- OSM nodes are converted to Points, ways to LineStrings and relations
 -- to GeometryCollections. If an object would create an invalid geometry
 -- it is still added to the table with a NULL geometry.
--- XXX expire will currently not work on these tables.
 local dtable = osm2pgsql.define_table{
     name = "data",
     -- This will generate a column "osm_id INT8" for the id, and a column

--- a/flex-config/untagged.lua
+++ b/flex-config/untagged.lua
@@ -41,4 +41,3 @@ end
 osm2pgsql.process_way = do_way
 osm2pgsql.process_untagged_way = do_way
 
-


### PR DESCRIPTION
Various cleanups in flex example config files
* Remove use of the clean_tags() function in some files
* Formatting changes
* Fix outdated or wrong comments