### PR TITLE
Add optional --end-at-sequence parameter to limit updates to a specific sequence number

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -551,6 +551,8 @@ def update(props, args):
     LOG.debug("Calling osm2pgsql with: %s", ' '.join(osm2pgsql))
 
     while seq < current.sequence:
+
+        # --------- new CODE --end-at-sequence
         LOG.debug("Importing from sequence %d", seq)
         if outfile.exists():
             outfile.unlink()
@@ -559,13 +561,21 @@ def update(props, args):
                                   max_size=args.max_diff_size * 1024)
         outhandler.close()
 
+        print(f"[DEBUG] Candidate sequence to apply: {endseq}")
+
         if endseq is None:
             LOG.debug("No new diffs found.")
             break
 
+        # Vérifie AVANT d'exécuter osm2pgsql
+        if args.end_at_sequence is not None and endseq > args.end_at_sequence:
+            print(f"Reached target sequence limit {args.end_at_sequence}. Stopping replication before applying.")
+            break
+
+        # Applique la mise à jour si on est dans la limite
         subprocess.run(osm2pgsql, check=True)
         seq = endseq
-
+                
         nextstate = repl.get_state_info(seq)
         if nextstate:
             timestamp = nextstate.timestamp
@@ -681,6 +691,11 @@ def get_parser():
                      help='Run updates only once, even when more data is available.')
     cmd.add_argument('--post-processing', metavar='SCRIPT',
                      help='Post-processing script to run after each execution of osm2pgsql.')
+
+    # handle option end-at-squence to stop a specific sequence number during update
+    cmd.add_argument('--end-at-sequence', type=int, default=None,
+                     help='Stop applying updates after reaching this sequence number (optional)')
+
 
     # Arguments for status
     cmd = subs.add_parser('status', parents=[default_args],


### PR DESCRIPTION
## Summary

This pull request introduces an **optional `--end-at-sequence` parameter** to `osm2pgsql-replication update`, allowing users to **limit the replication process to a specific sequence number**.

If provided, the replication process stops **before applying** any sequence **strictly greater** than the specified value.

---

## Motivation

When managing large datasets or performing staged updates, it is sometimes necessary to:

- **Apply updates incrementally**, stopping at a known sequence checkpoint.
- **Avoid consuming all available diffs** in a single run.
- **Synchronize updates across multiple systems** or environments by controlling the applied range.

This feature makes such workflows **safer** and **more predictable**, without impacting the default behavior when the option is not provided.

---

## Example usage

```bash
osm2pgsql-replication update --database=mydb --end-at-sequence=12345
```

- Applies all diffs **up to and including 12345**.
- **Stops before applying 12346 or higher**.

If `--end-at-sequence` is not specified, the replication process behaves **exactly as before**.

---

## Implementation Details

- The option is parsed and passed as `args.end_at_sequence` (integer, optional).
- The update loop **checks `endseq` before applying diffs**.
- **No changes** to the replication state if the stop condition is met.
- Includes **informative log messages** when stopping due to this limit.

---

## Compatibility

- **Backward-compatible**: default behavior is unchanged if the option is not used.
- **No impact** on existing workflows.

---

## Additional Notes

- This feature was designed to support **controlled or audited replication workflows**.
- It may be useful in **data pipelines**, **batch updates**, or **multi-stage import processes**.

---