### PR TITLE
Update CI builds for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, windows-2025]
+        os: [windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,17 +371,17 @@ jobs:
           cp -r Release/* ../README.md ../COPYING ../*.style ../scripts ../flex-config c:/vcpkg/installed/x64-windows/share/proj/proj.db c:/artifact/osm2pgsql-bin/
         shell: bash
         working-directory: build
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2025'
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
           name: osm2pgsql-win64
           path: c:/artifact
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2025'
 
   windows-package:
     needs: windows
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     env:
       OSMURL: https://download.geofabrik.de/europe/monaco-latest.osm.bz2


### PR DESCRIPTION
Removes Windows-2019 builds because Github is about to pull the image and moves building the osm2pgsql package to Windows-2025 to avoid compatibility issues (see #2326).