### PR TITLE
Consistent naming and type for "Lua class names"

### DIFF
--- a/src/flex-lua-expire-output.cpp
+++ b/src/flex-lua-expire-output.cpp
@@ -88,7 +88,7 @@ int setup_flex_expire_output(lua_State *lua_state,
     void *ptr = lua_newuserdata(lua_state, sizeof(std::size_t));
     auto *num = new (ptr) std::size_t{};
     *num = expire_outputs->size() - 1;
-    luaL_getmetatable(lua_state, osm2pgsql_expire_output_name);
+    luaL_getmetatable(lua_state, OSM2PGSQL_EXPIRE_OUTPUT_CLASS);
     lua_setmetatable(lua_state, -2);
 
     return 1;
@@ -100,7 +100,7 @@ int setup_flex_expire_output(lua_State *lua_state,
 void lua_wrapper_expire_output::init(lua_State *lua_state)
 {
     lua_getglobal(lua_state, "osm2pgsql");
-    if (luaL_newmetatable(lua_state, osm2pgsql_expire_output_name) != 1) {
+    if (luaL_newmetatable(lua_state, OSM2PGSQL_EXPIRE_OUTPUT_CLASS) != 1) {
         throw std::runtime_error{"Internal error: Lua newmetatable failed."};
     }
     lua_pushvalue(lua_state, -1); // Copy of new metatable

--- a/src/flex-lua-expire-output.hpp
+++ b/src/flex-lua-expire-output.hpp
@@ -18,7 +18,7 @@
 class expire_output_t;
 struct lua_State;
 
-static char const *const osm2pgsql_expire_output_name =
+static char const *const OSM2PGSQL_EXPIRE_OUTPUT_CLASS =
     "osm2pgsql.ExpireOutput";
 
 int setup_flex_expire_output(lua_State *lua_state,

--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -15,7 +15,7 @@
 
 #include <lua.hpp>
 
-static char const *const osm2pgsql_geometry_class = "osm2pgsql.Geometry";
+static char const *const OSM2PGSQL_GEOMETRY_CLASS = "osm2pgsql.Geometry";
 
 geom::geometry_t *create_lua_geometry_object(lua_State *lua_state)
 {
@@ -23,7 +23,7 @@ geom::geometry_t *create_lua_geometry_object(lua_State *lua_state)
     new (ptr) geom::geometry_t{};
 
     // Set the metatable of this object
-    luaL_getmetatable(lua_state, osm2pgsql_geometry_class);
+    luaL_getmetatable(lua_state, OSM2PGSQL_GEOMETRY_CLASS);
     lua_setmetatable(lua_state, -2);
 
     return static_cast<geom::geometry_t *>(ptr);
@@ -31,7 +31,7 @@ geom::geometry_t *create_lua_geometry_object(lua_State *lua_state)
 
 geom::geometry_t *unpack_geometry(lua_State *lua_state, int n) noexcept
 {
-    void *user_data = luaL_checkudata(lua_state, n, osm2pgsql_geometry_class);
+    void *user_data = luaL_checkudata(lua_state, n, OSM2PGSQL_GEOMETRY_CLASS);
     luaL_argcheck(lua_state, user_data != nullptr, n, "'Geometry' expected");
     return static_cast<geom::geometry_t *>(user_data);
 }
@@ -300,7 +300,7 @@ int geom_transform(lua_State *lua_state)
 void init_geometry_class(lua_State *lua_state)
 {
     lua_getglobal(lua_state, "osm2pgsql");
-    if (luaL_newmetatable(lua_state, osm2pgsql_geometry_class) != 1) {
+    if (luaL_newmetatable(lua_state, OSM2PGSQL_GEOMETRY_CLASS) != 1) {
         throw std::runtime_error{"Internal error: Lua newmetatable failed."};
     }
     lua_pushvalue(lua_state, -1); // Copy of new metatable

--- a/src/flex-lua-locator.cpp
+++ b/src/flex-lua-locator.cpp
@@ -59,7 +59,7 @@ int setup_flex_locator(lua_State *lua_state, std::vector<locator_t> *locators)
     void *ptr = lua_newuserdata(lua_state, sizeof(std::size_t));
     auto *num = new (ptr) std::size_t{};
     *num = locators->size() - 1;
-    luaL_getmetatable(lua_state, osm2pgsql_locator_name);
+    luaL_getmetatable(lua_state, OSM2PGSQL_LOCATOR_CLASS);
     lua_setmetatable(lua_state, -2);
 
     return 1;
@@ -71,7 +71,7 @@ void lua_wrapper_locator::init(lua_State *lua_state,
     s_connection_params = connection_params;
 
     lua_getglobal(lua_state, "osm2pgsql");
-    if (luaL_newmetatable(lua_state, osm2pgsql_locator_name) != 1) {
+    if (luaL_newmetatable(lua_state, OSM2PGSQL_LOCATOR_CLASS) != 1) {
         throw std::runtime_error{"Internal error: Lua newmetatable failed."};
     }
     lua_pushvalue(lua_state, -1); // Copy of new metatable

--- a/src/flex-lua-locator.hpp
+++ b/src/flex-lua-locator.hpp
@@ -23,7 +23,7 @@ class pg_conn_t;
 
 struct lua_State;
 
-static char const *const osm2pgsql_locator_name = "osm2pgsql.Locator";
+static char const *const OSM2PGSQL_LOCATOR_CLASS = "osm2pgsql.Locator";
 
 int setup_flex_locator(lua_State *lua_state, std::vector<locator_t> *locators);
 

--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -195,7 +195,7 @@ std::size_t idx_from_userdata(lua_State *lua_state, int idx,
         throw std::runtime_error{"Expire output must be of type ExpireOutput."};
     }
 
-    luaL_getmetatable(lua_state, osm2pgsql_expire_output_name);
+    luaL_getmetatable(lua_state, OSM2PGSQL_EXPIRE_OUTPUT_CLASS);
     if (!lua_rawequal(lua_state, -1, -2)) {
         throw std::runtime_error{"Expire output must be of type ExpireOutput."};
     }
@@ -445,7 +445,7 @@ int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
     void *ptr = lua_newuserdata(lua_state, sizeof(std::size_t));
     auto *num = new (ptr) std::size_t{};
     *num = tables->size() - 1;
-    luaL_getmetatable(lua_state, osm2pgsql_table_name);
+    luaL_getmetatable(lua_state, OSM2PGSQL_TABLE_CLASS);
     lua_setmetatable(lua_state, -2);
 
     return 1;
@@ -457,7 +457,7 @@ int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
 void lua_wrapper_table::init(lua_State *lua_state)
 {
     lua_getglobal(lua_state, "osm2pgsql");
-    if (luaL_newmetatable(lua_state, osm2pgsql_table_name) != 1) {
+    if (luaL_newmetatable(lua_state, OSM2PGSQL_TABLE_CLASS) != 1) {
         throw std::runtime_error{"Internal error: Lua newmetatable failed."};
     }
     lua_pushvalue(lua_state, -1); // Copy of new metatable

--- a/src/flex-lua-table.hpp
+++ b/src/flex-lua-table.hpp
@@ -19,7 +19,7 @@ class expire_output_t;
 class flex_table_t;
 struct lua_State;
 
-static char const *const osm2pgsql_table_name = "osm2pgsql.Table";
+static char const *const OSM2PGSQL_TABLE_CLASS = "osm2pgsql.Table";
 
 int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
                      std::vector<expire_output_t> *expire_outputs,

--- a/src/gen/osm2pgsql-gen.cpp
+++ b/src/gen/osm2pgsql-gen.cpp
@@ -565,7 +565,7 @@ genproc_t::genproc_t(std::string const &filename,
     luaX_add_table_func(lua_state(), "run_sql", lua_trampoline_app_run_sql);
 
     lua_getglobal(lua_state(), "osm2pgsql");
-    if (luaL_newmetatable(lua_state(), osm2pgsql_expire_output_name) != 1) {
+    if (luaL_newmetatable(lua_state(), OSM2PGSQL_EXPIRE_OUTPUT_CLASS) != 1) {
         throw std::runtime_error{"Internal error: Lua newmetatable failed."};
     }
     lua_pushvalue(lua_state(), -1); // Copy of new metatable

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -120,7 +120,7 @@ prepared_lua_function_t::prepared_lua_function_t(lua_State *lua_state,
 
 namespace {
 
-std::string_view const osm2pgsql_object_metatable = "osm2pgsql.OSMObject";
+char const *const OSM2PGSQL_OSMOBJECT_CLASS = "osm2pgsql.OSMObject";
 
 void push_osm_object_to_lua_stack(lua_State *lua_state,
                                   osmium::OSMObject const &object)
@@ -188,7 +188,7 @@ void push_osm_object_to_lua_stack(lua_State *lua_state,
     lua_rawset(lua_state, -3);
 
     // Set the metatable of this object
-    luaX_pushstring(lua_state, osm2pgsql_object_metatable);
+    lua_pushstring(lua_state, OSM2PGSQL_OSMOBJECT_CLASS);
     lua_gettable(lua_state, LUA_REGISTRYINDEX);
     lua_setmetatable(lua_state, -2);
 }
@@ -312,7 +312,7 @@ void check_for_object(lua_State *lua_state, char const *const function_name)
     }
 
     if (lua_getmetatable(lua_state, 1)) {
-        luaL_getmetatable(lua_state, osm2pgsql_object_metatable.data());
+        luaL_getmetatable(lua_state, OSM2PGSQL_OSMOBJECT_CLASS);
         if (lua_rawequal(lua_state, -1, -2)) {
             lua_pop(lua_state, 2); // remove the two metatables
             return;
@@ -608,19 +608,19 @@ int output_flex_t::app_define_expire_output()
 flex_table_t &output_flex_t::get_table_from_param()
 {
     return get_from_idx_param(lua_state(), m_tables.get(),
-                              osm2pgsql_table_name);
+                              OSM2PGSQL_TABLE_CLASS);
 }
 
 expire_output_t &output_flex_t::get_expire_output_from_param()
 {
     return get_from_idx_param(lua_state(), m_expire_outputs.get(),
-                              osm2pgsql_expire_output_name);
+                              OSM2PGSQL_EXPIRE_OUTPUT_CLASS);
 }
 
 locator_t &output_flex_t::get_locator_from_param()
 {
     return get_from_idx_param(lua_state(), m_locators.get(),
-                              osm2pgsql_locator_name);
+                              OSM2PGSQL_LOCATOR_CLASS);
 }
 
 bool output_flex_t::way_cache_t::init(middle_query_t const &middle, osmid_t id)
@@ -745,7 +745,7 @@ int output_flex_t::table_insert()
 
     // The first parameter is the table object.
     auto &table_connection = m_table_connections.at(
-        idx_from_param(lua_state(), osm2pgsql_table_name));
+        idx_from_param(lua_state(), OSM2PGSQL_TABLE_CLASS));
 
     // The second parameter must be a Lua table with the contents for the
     // fields.
@@ -1273,7 +1273,7 @@ void output_flex_t::init_lua(std::string const &filename,
 
     // Store the methods on OSM objects in its metatable.
     lua_getglobal(lua_state(), "object_metatable");
-    luaX_pushstring(lua_state(), osm2pgsql_object_metatable);
+    lua_pushstring(lua_state(), OSM2PGSQL_OSMOBJECT_CLASS);
     lua_setfield(lua_state(), -2, "__name");
     lua_getfield(lua_state(), -1, "__index");
     luaX_add_table_func(lua_state(), "get_bbox", lua_trampoline_app_get_bbox);
@@ -1296,7 +1296,7 @@ void output_flex_t::init_lua(std::string const &filename,
     // Store the global object "object_metatable" defined in the init.lua
     // script in the registry and then remove the global object. It will
     // later be used as metatable for OSM objects.
-    luaX_pushstring(lua_state(), osm2pgsql_object_metatable);
+    lua_pushstring(lua_state(), OSM2PGSQL_OSMOBJECT_CLASS);
     lua_getglobal(lua_state(), "object_metatable");
     lua_settable(lua_state(), LUA_REGISTRYINDEX);
     lua_pushnil(lua_state());


### PR DESCRIPTION
* Using uppercase, because they are constants
* Using the word "CLASS" because it is easier to understand then the generic "name" or the Luaish "metatable"
* Using char* not std::string_view, because its simpler use (no .data() needed)

This is for all the Lua "classes" that we use in flex config files:

* ExpireOutput
* Geometry
* Locator
* OSMObject
* Table