### PR TITLE
Allow --username and --user in osm2pgsql and osm2pgsql-replication

### DIFF
--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -79,7 +79,7 @@ mandatory for short options too.
     `postgres://`), it is treated as a conninfo string. See the PostgreSQL
     manual for details.
 
--U, \--username=NAME
+-U, \--username=NAME, \--user=NAME
 :   Postgresql user name.
 
 -W, \--password

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -627,7 +627,7 @@ def get_parser():
       "see https://www.postgresql.org/docs/current/libpq-pgpass.html.")
     group.add_argument('-d', '--database', metavar='DB',
                        help='Name of PostgreSQL database to connect to or conninfo string')
-    group.add_argument('-U', '--username', metavar='NAME',
+    group.add_argument('-U', '--username', '--user', metavar='NAME',
                        help='PostgreSQL user name')
     group.add_argument('-H', '--host', metavar='HOST',
                        help='Database server host name or socket location')

--- a/src/command-line-app.cpp
+++ b/src/command-line-app.cpp
@@ -41,7 +41,7 @@ void command_line_app_t::init_database_options()
         ->type_name("DB")
         ->group("Database options");
 
-    add_option_function<std::string>("-U,--user",
+    add_option_function<std::string>("-U,--username,--user",
                                      [&](std::string const &value) {
                                          m_connection_params.set("user", value);
                                      })


### PR DESCRIPTION
This was inconsistent and documented wrong. We prefer the --username variant, because that is consistent with psql, but both work now everwhere.

See #2342