### PR TITLE
Add callbacks for delete actions

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -54,7 +54,7 @@ void osmdata_t::node(osmium::Node const &node)
     m_mid->node(node);
 
     if (node.deleted()) {
-        m_output->node_delete(node.id());
+        m_output->node_delete(node);
         return;
     }
 
@@ -94,7 +94,7 @@ void osmdata_t::way(osmium::Way &way)
     m_mid->way(way);
 
     if (way.deleted()) {
-        m_output->way_delete(way.id());
+        m_output->way_delete(&way);
         return;
     }
 
@@ -161,7 +161,7 @@ void osmdata_t::relation(osmium::Relation const &rel)
     m_mid->relation(rel);
 
     if (rel.deleted()) {
-        m_output->relation_delete(rel.id());
+        m_output->relation_delete(rel);
         return;
     }
 

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -31,9 +31,7 @@ osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid,
 : m_mid(std::move(mid)), m_output(std::move(output)),
   m_connection_params(options.connection_params), m_bbox(options.bbox),
   m_num_procs(options.num_procs), m_append(options.append),
-  m_droptemp(options.droptemp),
-  m_with_extra_attrs(options.extra_attributes ||
-                     options.output_backend == "flex")
+  m_droptemp(options.droptemp)
 {
     assert(m_mid);
     assert(m_output);
@@ -60,13 +58,8 @@ void osmdata_t::node(osmium::Node const &node)
         return;
     }
 
-    bool const has_tags_or_attrs = m_with_extra_attrs || !node.tags().empty();
     if (m_append) {
-        if (has_tags_or_attrs) {
-            m_output->node_modify(node);
-        } else {
-            m_output->node_delete(node.id());
-        }
+        m_output->node_modify(node);
 
         // Version 1 means this is a new node, so there can't be an existing
         // way or relation referencing it, so we don't have to add that node
@@ -75,7 +68,7 @@ void osmdata_t::node(osmium::Node const &node)
         if (node.version() != 1) {
             m_changed_nodes.push_back(node.id());
         }
-    } else if (has_tags_or_attrs) {
+    } else {
         m_output->node_add(node);
     }
 }
@@ -105,13 +98,8 @@ void osmdata_t::way(osmium::Way &way)
         return;
     }
 
-    bool const has_tags_or_attrs = m_with_extra_attrs || !way.tags().empty();
     if (m_append) {
-        if (has_tags_or_attrs) {
-            m_output->way_modify(&way);
-        } else {
-            m_output->way_delete(way.id());
-        }
+        m_output->way_modify(&way);
 
         // Version 1 means this is a new way, so there can't be an existing
         // relation referencing it, so we don't have to add that way to the
@@ -120,7 +108,7 @@ void osmdata_t::way(osmium::Way &way)
         if (way.version() != 1) {
             m_changed_ways.push_back(way.id());
         }
-    } else if (has_tags_or_attrs) {
+    } else {
         m_output->way_add(&way);
     }
 }
@@ -177,15 +165,10 @@ void osmdata_t::relation(osmium::Relation const &rel)
         return;
     }
 
-    bool const has_tags_or_attrs = m_with_extra_attrs || !rel.tags().empty();
     if (m_append) {
-        if (has_tags_or_attrs) {
-            m_output->relation_modify(rel);
-        } else {
-            m_output->relation_delete(rel.id());
-        }
+        m_output->relation_modify(rel);
         m_changed_relations.push_back(rel.id());
-    } else if (has_tags_or_attrs) {
+    } else {
         m_output->relation_add(rel);
     }
 }

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -117,7 +117,6 @@ private:
     unsigned int m_num_procs;
     bool m_append;
     bool m_droptemp;
-    bool m_with_extra_attrs;
 };
 
 #endif // OSM2PGSQL_OSMDATA_HPP

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -43,9 +43,9 @@ struct options_t;
 enum class calling_context : std::uint8_t
 {
     main = 0, ///< In main context, i.e. the Lua script outside any callbacks
-    process_node = 1, ///< In the process_node() callback
-    process_way = 2, ///< In the process_way() callback
-    process_relation = 3, ///< In the process_relation() callback
+    process_node = 1, ///< Inside a callback where a node is handled
+    process_way = 2, ///< Inside a callback where a way is handled
+    process_relation = 3, ///< Inside a callback where a relation is handled
     select_relation_members = 4 ///< In the select_relation_members() callback
 };
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -147,9 +147,9 @@ public:
     void way_modify(osmium::Way *way) override;
     void relation_modify(osmium::Relation const &rel) override;
 
-    void node_delete(osmid_t id) override;
-    void way_delete(osmid_t id) override;
-    void relation_delete(osmid_t id) override;
+    void node_delete(osmium::Node const &node) override;
+    void way_delete(osmium::Way *way) override;
+    void relation_delete(osmium::Relation const &rel) override;
 
     void merge_expire_trees(output_t *other) override;
 
@@ -203,6 +203,10 @@ private:
 
     osmium::OSMObject const &
     check_and_get_context_object(flex_table_t const &table);
+
+    void node_delete(osmid_t id);
+    void way_delete(osmid_t id);
+    void relation_delete(osmid_t id);
 
     void delete_from_table(table_connection_t *table_connection,
                            pg_conn_t const &db_connection,
@@ -303,6 +307,10 @@ private:
     prepared_lua_function_t m_process_untagged_node;
     prepared_lua_function_t m_process_untagged_way;
     prepared_lua_function_t m_process_untagged_relation;
+
+    prepared_lua_function_t m_delete_node;
+    prepared_lua_function_t m_delete_way;
+    prepared_lua_function_t m_delete_relation;
 
     prepared_lua_function_t m_select_relation_members;
 

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -50,9 +50,9 @@ public:
     void way_modify(osmium::Way * /*way*/) override {}
     void relation_modify(osmium::Relation const & /*rel*/) override {}
 
-    void node_delete(osmid_t /*id*/) override {}
-    void way_delete(osmid_t /*id*/) override {}
-    void relation_delete(osmid_t /*id*/) override {}
+    void node_delete(osmium::Node const & /*node*/) override {}
+    void way_delete(osmium::Way * /*way*/) override {}
+    void relation_delete(osmium::Relation const & /*rel*/) override {}
 };
 
 #endif // OSM2PGSQL_OUTPUT_NULL_HPP

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -100,6 +100,8 @@ private:
 
     //enable output of a generated way_area tag to either hstore or its own column
     bool m_enable_way_area;
+    // handle objects without tags as if they were not there
+    bool m_ignore_untagged_objects;
 
     std::array<std::unique_ptr<table_t>, t_MAX> m_tables;
 

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -76,9 +76,9 @@ public:
     void way_modify(osmium::Way *way) override;
     void relation_modify(osmium::Relation const &rel) override;
 
-    void node_delete(osmid_t id) override;
-    void way_delete(osmid_t id) override;
-    void relation_delete(osmid_t id) override;
+    void node_delete(osmium::Node const &node) override;
+    void way_delete(osmium::Way *way) override;
+    void relation_delete(osmium::Relation const &rel) override;
 
     void merge_expire_trees(output_t *other) override;
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -98,9 +98,9 @@ public:
     virtual void way_modify(osmium::Way *way) = 0;
     virtual void relation_modify(osmium::Relation const &rel) = 0;
 
-    virtual void node_delete(osmid_t id) = 0;
-    virtual void way_delete(osmid_t id) = 0;
-    virtual void relation_delete(osmid_t id) = 0;
+    virtual void node_delete(osmium::Node const &node) = 0;
+    virtual void way_delete(osmium::Way *way) = 0;
+    virtual void relation_delete(osmium::Relation const &rel) = 0;
 
     virtual void merge_expire_trees(output_t * /*other*/) {}
 

--- a/tests/bdd/flex/delete-callbacks.feature
+++ b/tests/bdd/flex/delete-callbacks.feature
@@ -1,0 +1,112 @@
+Feature: Test for delete callbacks
+
+    Background:
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local change = osm2pgsql.define_table{
+                name = 'change',
+                ids = {type = 'any', id_column = 'osm_id', type_column = 'osm_type'},
+                columns = {
+                    { column = 'extra', type = 'int' }
+                }}
+
+            local function process_delete(object)
+                change:insert{extra = object.version}
+            end
+
+            osm2pgsql.delete_node = process_delete
+            osm2pgsql.delete_way = process_delete
+            osm2pgsql.delete_relation = process_delete
+            """
+        When running osm2pgsql flex with parameters
+            | --slim |
+
+        Then table change contains exactly
+            | osm_type | osm_id |
+
+        Given the input file '008-ch.osc.gz'
+
+    Scenario: Delete callbacks are called
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+
+        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
+            | osm_type | count | sum |
+            | N        | 16773 | 16779 |
+            | W        | 4     | 9 |
+            | R        | 1     | 3 |
+
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+
+        Then SELECT osm_type, count(*), sum(osm_id) FROM change GROUP BY osm_type
+            | osm_type | count | sum |
+            | N        | 16773 | 37856781001834 |
+            | W        | 4     | 350933407 |
+            | R        | 1     | 2871571 |
+
+    Scenario: No object payload is available
+        Given the lua style
+            """
+            local change = osm2pgsql.define_table{
+                name = 'change',
+                ids = {type = 'any', id_column = 'osm_id', type_column = 'osm_type'},
+                columns = {
+                    { column = 'extra', type = 'int' }
+                }}
+
+            function osm2pgsql.delete_node(object)
+                change:insert{extra = object.tags == nil and 1 or 0}
+            end
+
+            function osm2pgsql.delete_way(object)
+                change:insert{extra = object.nodes == nil and 1 or 0}
+            end
+
+            function osm2pgsql.delete_relation(object)
+                change:insert{extra = object.members == nil and 1 or 0}
+            end
+
+
+            """
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
+            | osm_type | count | sum |
+            | N        | 16773 | 16773 |
+            | W        | 4     | 4 |
+            | R        | 1     | 1 |
+
+
+    Scenario: Geometries are not valid for deleted objects
+        Given the lua style
+            """
+            change = osm2pgsql.define_table{
+                name = 'change',
+                ids = {type = 'any', id_column = 'osm_id', type_column = 'osm_type'},
+                columns = {
+                    { column = 'extra', sql_type = 'int' }
+                }}
+
+            function osm2pgsql.delete_node(object)
+                change:insert{extra = object.as_point == nil and 1 or 0}
+            end
+
+            function osm2pgsql.delete_way(object)
+                change:insert{extra = object.as_linestring == nil and 1 or 0}
+            end
+
+            function osm2pgsql.delete_relation(object)
+                change:insert{extra = object.as_geometrycollection == nil and 1 or 0}
+            end
+
+
+            """
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
+            | osm_type | count | sum |
+            | N        | 16773 | 16773|
+            | W        | 4     | 4|
+            | R        | 1     | 1|

--- a/tests/test-osm-file-parsing.cpp
+++ b/tests/test-osm-file-parsing.cpp
@@ -154,13 +154,13 @@ TEST_CASE("parse xml file")
     testing::parse_file(options, middle, output, "test_multipolygon.osm",
                         false);
 
-    REQUIRE(output->sum_ids == 4728);
-    REQUIRE(output->sum_nds == 186);
+    REQUIRE(output->sum_ids == 73514);
+    REQUIRE(output->sum_nds == 495);
     REQUIRE(output->sum_members == 146);
-    REQUIRE(output->node.added == 0);
+    REQUIRE(output->node.added == 353);
     REQUIRE(output->node.modified == 0);
     REQUIRE(output->node.deleted == 0);
-    REQUIRE(output->way.added == 48);
+    REQUIRE(output->way.added == 140);
     REQUIRE(output->way.modified == 0);
     REQUIRE(output->way.deleted == 0);
     REQUIRE(output->relation.added == 40);
@@ -188,8 +188,8 @@ TEST_CASE("parse diff file")
     testing::parse_file(options, middle, output, "008-ch.osc.gz", false);
 
     REQUIRE(output->node.added == 0);
-    REQUIRE(output->node.modified == 153);
-    REQUIRE(output->node.deleted == 17796);
+    REQUIRE(output->node.modified == 1176);
+    REQUIRE(output->node.deleted == 16773);
     REQUIRE(output->way.added == 0);
     REQUIRE(output->way.modified == 161);
     REQUIRE(output->way.deleted == 4);

--- a/tests/test-osm-file-parsing.cpp
+++ b/tests/test-osm-file-parsing.cpp
@@ -130,11 +130,11 @@ struct counting_output_t : public output_null_t
         ++relation.modified;
     }
 
-    void node_delete(osmid_t) override { ++node.deleted; }
+    void node_delete(osmium::Node const &) override { ++node.deleted; }
 
-    void way_delete(osmid_t) override { ++way.deleted; }
+    void way_delete(osmium::Way *) override { ++way.deleted; }
 
-    void relation_delete(osmid_t) override { ++relation.deleted; }
+    void relation_delete(osmium::Relation const &) override { ++relation.deleted; }
 
     type_stats_t node, way, relation;
     uint64_t sum_ids = 0;


### PR DESCRIPTION
This adds callbacks `delete_node` \ `delete_way` \ `delete_relation`. They are called for every object that is explicitly marked as deleted in a change file. The callbacks are not called for objects that are implicitly deleted to make room for a new version of the object.

The callbacks receive an OSM object as a single parameter -- just like the other callbacks --, only the tags, nodes and member attributes as well as all geometry creation functions are disabled. This kind of information is usually not available for deleted objects. You can still access meta information like version, user etc. and use the object to insert something into a table.

This change required some cleanup to the code that handles untagged nodes. The pgsql output has some special handling in that it ignores untagged objects unless attribute handling is requested. We've long since removed the special handling for flex but the code for filtering was still in osmdata. This PR moves the handling into the pgsql output, which is a bit cleaner. This changes some of the outcome in the tests. See first commit for details.