### PR TITLE
Refactor: Use std::string not std::string_view

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -221,7 +221,7 @@ void db_copy_thread_t::thread_t::start_copy(
     }
 
     sql.push_back('\0');
-    m_db_connection.copy_start(sql.data());
+    m_db_connection.copy_start(to_string(sql));
 
     m_inflight = target;
 }

--- a/src/gen/gen-base.cpp
+++ b/src/gen/gen-base.cpp
@@ -99,14 +99,14 @@ pg_result_t gen_base_t::dbexec(params_t const &tmp_params,
     return connection().exec(sql_template.render());
 }
 
-void gen_base_t::dbprepare(std::string_view stmt, std::string const &templ)
+void gen_base_t::dbprepare(std::string const &stmt, std::string const &templ)
 {
     template_t sql_template{templ};
     sql_template.set_params(get_params());
     connection().prepare(stmt, fmt::runtime(sql_template.render()));
 }
 
-void gen_base_t::dbprepare(std::string_view stmt, params_t const &tmp_params,
+void gen_base_t::dbprepare(std::string const &stmt, params_t const &tmp_params,
                            std::string const &templ)
 {
     template_t sql_template{templ};

--- a/src/gen/gen-base.hpp
+++ b/src/gen/gen-base.hpp
@@ -101,9 +101,9 @@ protected:
 
     pg_result_t dbexec(params_t const &tmp_params, std::string const &templ);
 
-    void dbprepare(std::string_view stmt, std::string const &templ);
+    void dbprepare(std::string const &stmt, std::string const &templ);
 
-    void dbprepare(std::string_view stmt, params_t const &tmp_params,
+    void dbprepare(std::string const &stmt, params_t const &tmp_params,
                    std::string const &templ);
 
     void raster_table_preprocess(std::string const &table);

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -93,7 +93,7 @@ void middle_pgsql_t::dbexec(std::string_view templ) const
     m_db_connection.exec(render_template(templ));
 }
 
-void middle_query_pgsql_t::prepare(std::string_view stmt,
+void middle_query_pgsql_t::prepare(std::string const &stmt,
                                    std::string const &sql_cmd) const
 {
     m_db_connection.prepare(stmt, fmt::runtime(sql_cmd));

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -71,7 +71,7 @@ public:
     bool relation_get(osmid_t id,
                       osmium::memory::Buffer *buffer) const override;
 
-    void prepare(std::string_view stmt, std::string const &sql_cmd) const;
+    void prepare(std::string const &stmt, std::string const &sql_cmd) const;
 
 private:
     osmium::Location get_node_location_flatnodes(osmid_t id) const;

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -136,12 +136,12 @@ pg_result_t pg_conn_t::exec(std::string const &sql) const
     return exec(sql.c_str());
 }
 
-void pg_conn_t::copy_start(std::string_view sql) const
+void pg_conn_t::copy_start(std::string const &sql) const
 {
     assert(m_conn);
 
     log_sql("(C{}) {}", m_connection_id, sql);
-    pg_result_t const res{PQexec(m_conn.get(), sql.data())};
+    pg_result_t const res{PQexec(m_conn.get(), sql.c_str())};
     if (res.status() != PGRES_COPY_IN) {
         throw fmt_error("Database error on COPY: {}", error_msg());
     }

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -194,15 +194,15 @@ void pg_conn_t::copy_end(std::string_view context) const
     }
 }
 
-void pg_conn_t::prepare_internal(std::string_view stmt,
-                                 std::string_view sql) const
+void pg_conn_t::prepare_internal(std::string const &stmt,
+                                 std::string const &sql) const
 {
     if (get_logger().log_sql()) {
         log_sql("(C{}) PREPARE {} AS {}", m_connection_id, stmt, sql);
     }
 
     pg_result_t const res{
-        PQprepare(m_conn.get(), stmt.data(), sql.data(), 0, nullptr)};
+        PQprepare(m_conn.get(), stmt.c_str(), sql.c_str(), 0, nullptr)};
     if (res.status() != PGRES_COMMAND_OK) {
         throw fmt_error("Prepare failed for '{}': {}.", sql, error_msg());
     }

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -241,7 +241,7 @@ public:
      */
     void set_config(char const *setting, char const *value) const;
 
-    void copy_start(std::string_view sql) const;
+    void copy_start(std::string const &sql) const;
     void copy_send(std::string_view data, std::string_view context) const;
     void copy_end(std::string_view context) const;
 

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -195,7 +195,7 @@ public:
      *         status code PGRES_COMMAND_OK).
      */
     template <typename... TArgs>
-    void prepare(std::string_view stmt, fmt::format_string<TArgs...> sql,
+    void prepare(std::string const &stmt, fmt::format_string<TArgs...> sql,
                  TArgs... params) const
     {
         std::string const query =
@@ -252,7 +252,8 @@ public:
     void close();
 
 private:
-    void prepare_internal(std::string_view stmt, std::string_view sql) const;
+    void prepare_internal(std::string const &stmt,
+                          std::string const &sql) const;
 
     pg_result_t exec_prepared_internal(char const *stmt, int num_params,
                                        char const *const *param_values,


### PR DESCRIPTION
Because std::string guarantees that there is a \0 at the end which we need for the C interface of the PostgreSQL library.

Gets rid of clang-tidy warnings.