### PR TITLE
Improve naming of delete callbacks

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1089,9 +1089,9 @@ void output_flex_t::delete_from_tables(osmium::item_type type, osmid_t osm_id)
 
 void output_flex_t::node_delete(osmium::Node const &node)
 {
-    if (m_delete_node) {
+    if (m_process_deleted_node) {
         m_context_node = &node;
-        get_mutex_and_call_lua_function(m_delete_node, node);
+        get_mutex_and_call_lua_function(m_process_deleted_node, node);
         m_context_node = nullptr;
     }
 
@@ -1100,9 +1100,9 @@ void output_flex_t::node_delete(osmium::Node const &node)
 
 void output_flex_t::way_delete(osmium::Way *way)
 {
-    if (m_delete_way) {
+    if (m_process_deleted_way) {
         m_way_cache.init(way);
-        get_mutex_and_call_lua_function(m_delete_way, m_way_cache.get());
+        get_mutex_and_call_lua_function(m_process_deleted_way, m_way_cache.get());
     }
 
     way_delete(way->id());
@@ -1110,9 +1110,9 @@ void output_flex_t::way_delete(osmium::Way *way)
 
 void output_flex_t::relation_delete(osmium::Relation const &rel)
 {
-    if (m_delete_relation) {
+    if (m_process_deleted_relation) {
         m_relation_cache.init(rel);
-        get_mutex_and_call_lua_function(m_delete_relation, rel);
+        get_mutex_and_call_lua_function(m_process_deleted_relation, rel);
     }
 
     relation_delete(rel.id());
@@ -1180,8 +1180,9 @@ output_flex_t::output_flex_t(output_flex_t const *other,
   m_process_untagged_node(other->m_process_untagged_node),
   m_process_untagged_way(other->m_process_untagged_way),
   m_process_untagged_relation(other->m_process_untagged_relation),
-  m_delete_node(other->m_delete_node), m_delete_way(other->m_delete_way),
-  m_delete_relation(other->m_delete_relation),
+  m_process_deleted_node(other->m_process_deleted_node),
+  m_process_deleted_way(other->m_process_deleted_way),
+  m_process_deleted_relation(other->m_process_deleted_relation),
   m_select_relation_members(other->m_select_relation_members),
   m_after_nodes(other->m_after_nodes), m_after_ways(other->m_after_ways),
   m_after_relations(other->m_after_relations)
@@ -1369,12 +1370,12 @@ void output_flex_t::init_lua(std::string const &filename,
         prepared_lua_function_t{lua_state(), calling_context::process_relation,
                                 "process_untagged_relation"};
 
-    m_delete_node = prepared_lua_function_t{
-        lua_state(), calling_context::process_node, "delete_node"};
-    m_delete_way = prepared_lua_function_t{
-        lua_state(), calling_context::process_way, "delete_way"};
-    m_delete_relation = prepared_lua_function_t{
-        lua_state(), calling_context::process_relation, "delete_relation"};
+    m_process_deleted_node = prepared_lua_function_t{
+        lua_state(), calling_context::process_node, "process_deleted_node"};
+    m_process_deleted_way = prepared_lua_function_t{
+        lua_state(), calling_context::process_way, "process_deleted_way"};
+    m_process_deleted_relation = prepared_lua_function_t{
+        lua_state(), calling_context::process_relation, "process_deleted_relation"};
 
     m_select_relation_members = prepared_lua_function_t{
         lua_state(), calling_context::select_relation_members,

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -308,9 +308,9 @@ private:
     prepared_lua_function_t m_process_untagged_way;
     prepared_lua_function_t m_process_untagged_relation;
 
-    prepared_lua_function_t m_delete_node;
-    prepared_lua_function_t m_delete_way;
-    prepared_lua_function_t m_delete_relation;
+    prepared_lua_function_t m_process_deleted_node;
+    prepared_lua_function_t m_process_deleted_way;
+    prepared_lua_function_t m_process_deleted_relation;
 
     prepared_lua_function_t m_select_relation_members;
 

--- a/tests/bdd/flex/delete-callbacks.feature
+++ b/tests/bdd/flex/delete-callbacks.feature
@@ -15,9 +15,9 @@ Feature: Test for delete callbacks
                 change:insert{extra = object.version}
             end
 
-            osm2pgsql.delete_node = process_delete
-            osm2pgsql.delete_way = process_delete
-            osm2pgsql.delete_relation = process_delete
+            osm2pgsql.process_deleted_node = process_delete
+            osm2pgsql.process_deleted_way = process_delete
+            osm2pgsql.process_deleted_relation = process_delete
             """
         When running osm2pgsql flex with parameters
             | --slim |
@@ -56,15 +56,15 @@ Feature: Test for delete callbacks
                     { column = 'extra', type = 'int' }
                 }}
 
-            function osm2pgsql.delete_node(object)
+            function osm2pgsql.process_deleted_node(object)
                 change:insert{extra = object.tags == nil and 1 or 0}
             end
 
-            function osm2pgsql.delete_way(object)
+            function osm2pgsql.process_deleted_way(object)
                 change:insert{extra = object.nodes == nil and 1 or 0}
             end
 
-            function osm2pgsql.delete_relation(object)
+            function osm2pgsql.process_deleted_relation(object)
                 change:insert{extra = object.members == nil and 1 or 0}
             end
 
@@ -89,15 +89,15 @@ Feature: Test for delete callbacks
                     { column = 'extra', sql_type = 'int' }
                 }}
 
-            function osm2pgsql.delete_node(object)
+            function osm2pgsql.process_deleted_node(object)
                 change:insert{extra = object.as_point == nil and 1 or 0}
             end
 
-            function osm2pgsql.delete_way(object)
+            function osm2pgsql.process_deleted_way(object)
                 change:insert{extra = object.as_linestring == nil and 1 or 0}
             end
 
-            function osm2pgsql.delete_relation(object)
+            function osm2pgsql.process_deleted_relation(object)
                 change:insert{extra = object.as_geometrycollection == nil and 1 or 0}
             end
 


### PR DESCRIPTION
Trying to use the delete callbacks in practice it turned out that the naming is somewhat inconsistent with what we already have. Given a callback named `process_thing` and `processed_untagged_thing`, the more obvious naming is `process_deleted_thing`.