### PR TITLE
Workaround for int that is too large

### DIFF
--- a/tests/test-output-pgsql-int4.cpp
+++ b/tests/test-output-pgsql-int4.cpp
@@ -44,7 +44,7 @@ TEST_CASE("int4 conversion")
     CHECK(2147483647 == conn.result_as_int(population(4)));
     CHECK(10000 == conn.result_as_int(population(5)));
     CHECK(-10000 == conn.result_as_int(population(6)));
-    CHECK(-2147483648 == conn.result_as_int(population(7)));
+    CHECK((-2147483647 - 1) == conn.result_as_int(population(7)));
 
     // More out of range negative values
     conn.assert_null(population(8));
@@ -59,7 +59,7 @@ TEST_CASE("int4 conversion")
     CHECK(2147483647 == conn.result_as_int(population(13)));
     CHECK(15000 == conn.result_as_int(population(14)));
     CHECK(-15000 == conn.result_as_int(population(15)));
-    CHECK(-2147483648 == conn.result_as_int(population(16)));
+    CHECK((-2147483647 - 1) == conn.result_as_int(population(16)));
 
     // More out of range negative values
     conn.assert_null(population(17));


### PR DESCRIPTION
Fixes MSVC warning. This is due to the way integer literals are parsed.