### PR TITLE
Fix bbox calculation for relation with node members

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -430,9 +430,9 @@ int output_flex_t::app_get_bbox()
         osmium::Box bbox;
 
         // Bounding boxes of all the member nodes
-        for (auto const &wnl :
-             m_relation_cache.members_buffer().select<osmium::WayNodeList>()) {
-            bbox.extend(wnl.envelope());
+        for (auto const &node :
+             m_relation_cache.members_buffer().select<osmium::Node>()) {
+            bbox.extend(node.location());
         }
 
         // Bounding boxes of all the member ways


### PR DESCRIPTION
The old code is some left-over from before that was not working any more.