### PR TITLE
Fix: Untagged member nodes of relations not found

### DIFF
--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -341,21 +341,20 @@ middle_ram_t::rel_members_get(osmium::Relation const &rel,
         switch (member.type()) {
         case osmium::item_type::node:
             if (m_store_options.nodes) {
-                auto const offset =
-                    m_object_index.nodes().get(member.ref());
+                auto const offset = m_object_index.nodes().get(member.ref());
                 if (offset != ordered_index_t::not_found_value()) {
                     buffer->add_item(m_object_buffer.get<osmium::Node>(offset));
                     buffer->commit();
                     ++count;
+                    continue;
                 }
-            } else {
-                {
-                    osmium::builder::NodeBuilder builder{*buffer};
-                    builder.set_id(member.ref());
-                }
-                buffer->commit();
-                ++count;
             }
+            {
+                osmium::builder::NodeBuilder builder{*buffer};
+                builder.set_id(member.ref());
+            }
+            buffer->commit();
+            ++count;
             break;
         case osmium::item_type::way:
             if (m_store_options.ways) {


### PR DESCRIPTION
When looking up member nodes in the RAM middle: Only tagged nodes are in the object store, untagged nodes were not added to the result. This change adds nodes not found in the object store with just their ID. Later code will then find and add the locations.

Replaces #2365.