### PR TITLE
Reorganize the way we are printing version numbers

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -10,7 +10,6 @@
 #include "command-line-parser.hpp"
 
 #include "command-line-app.hpp"
-#include "format.hpp"
 #include "logging.hpp"
 #include "options.hpp"
 #include "pgsql.hpp"
@@ -20,11 +19,8 @@
 #include "version.hpp"
 
 #include <osmium/util/string.hpp>
-#include <osmium/version.hpp>
 
 #include <CLI/CLI.hpp>
-
-#include <lua.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -253,20 +249,6 @@ void check_options_expire(options_t *options) {
 }
 
 } // anonymous namespace
-
-void print_version()
-{
-    fmt::print(stderr, "osm2pgsql version {}\n", get_osm2pgsql_version());
-    fmt::print(stderr, "Build: {}\n", get_build_type());
-    fmt::print(stderr, "Compiled using the following library versions:\n");
-    fmt::print(stderr, "Libosmium {}\n", LIBOSMIUM_VERSION_STRING);
-    fmt::print(stderr, "Proj {}\n", get_proj_version());
-#ifdef HAVE_LUAJIT
-    fmt::print(stderr, "{} ({})\n", LUA_RELEASE, LUAJIT_VERSION);
-#else
-    fmt::print(stderr, "{}\n", LUA_RELEASE);
-#endif
-}
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 options_t parse_command_line(int argc, char *argv[])

--- a/src/command-line-parser.hpp
+++ b/src/command-line-parser.hpp
@@ -15,6 +15,4 @@
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 options_t parse_command_line(int argc, char *argv[]);
 
-void print_version();
-
 #endif // OSM2PGSQL_COMMAND_LINE_PARSER_HPP

--- a/src/gen/osm2pgsql-gen.cpp
+++ b/src/gen/osm2pgsql-gen.cpp
@@ -42,6 +42,10 @@
 
 #include <lua.hpp>
 
+#include <potracelib.h>
+
+#include <opencv2/core/version.hpp>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -685,12 +689,15 @@ int main(int argc, char *argv[])
             return 0;
         }
 
-        log_info("osm2pgsql-gen version {}", get_osm2pgsql_version());
-        log_warn("This is an EXPERIMENTAL extension to osm2pgsql.");
-
         if (app.want_version()) {
+            print_version("osm2pgsql-gen");
+            fmt::print(stderr, "OpenCV {}\n", CV_VERSION);
+            fmt::print(stderr, "{}\n", potrace_version());
             return 0;
         }
+
+        log_info("osm2pgsql-gen version {}", get_osm2pgsql_version());
+        log_warn("This is an EXPERIMENTAL extension to osm2pgsql.");
 
         if (dbschema.empty()) {
             log_error("Schema must not be empty");

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -339,7 +339,7 @@ int main(int argc, char *argv[])
         }
 
         if (options.command == command_t::version) {
-            print_version();
+            print_version("osm2pgsql");
             return 0;
         }
 

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -7,7 +7,15 @@
  * For a full list of authors see the git log.
  */
 
+#include "format.hpp"
+#include "reprojection.hpp"
 #include "version.hpp"
+
+#include <osmium/version.hpp>
+
+#include <lua.hpp>
+
+#include <nlohmann/json.hpp>
 
 char const *get_build_type() noexcept
 {
@@ -34,3 +42,18 @@ uint32_t get_minimum_postgresql_server_version_num() noexcept
     return @MINIMUM_POSTGRESQL_SERVER_VERSION_NUM@;
 }
 
+void print_version(std::string const &command)
+{
+    fmt::print(stderr, "{} version {}\n", command, get_osm2pgsql_version());
+    fmt::print(stderr, "Build: {}\n", get_build_type());
+    fmt::print(stderr, "Compiled using the following library versions:\n");
+    fmt::print(stderr, "Libosmium {}\n", LIBOSMIUM_VERSION_STRING);
+    fmt::print(stderr, "Proj {}\n", get_proj_version());
+    fmt::print(stderr, "nlohmann JSON {}.{}.{}\n", NLOHMANN_JSON_VERSION_MAJOR,
+               NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH);
+#ifdef HAVE_LUAJIT
+    fmt::print(stderr, "{} ({})\n", LUA_RELEASE, LUAJIT_VERSION);
+#else
+    fmt::print(stderr, "{}\n", LUA_RELEASE);
+#endif
+}

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -11,11 +11,14 @@
  */
 
 #include <cstdint>
+#include <string>
 
 char const *get_build_type() noexcept;
 char const *get_osm2pgsql_version() noexcept;
 char const *get_osm2pgsql_short_version() noexcept;
 char const *get_minimum_postgresql_server_version() noexcept;
 uint32_t get_minimum_postgresql_server_version_num() noexcept;
+
+void print_version(std::string const &command);
 
 #endif // OSM2PGSQL_VERSION_HPP


### PR DESCRIPTION
To unify the way we print the version number on startup and when using --version for the osm2pgsql and osm2pgsql-gen commands, respectively.

Also show more libraries used with --version.