### PR TITLE
Process untagged ways/relations in stage 1b/c correctly

### DIFF
--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -196,6 +196,8 @@ private:
     void get_mutex_and_call_lua_function(prepared_lua_function_t func,
                                          osmium::OSMObject const &object);
 
+    void process_relation();
+
     void init_lua(std::string const &filename, properties_t const &properties);
 
     void check_context_and_state(char const *name, char const *context,

--- a/tests/bdd/flex/untagged.feature
+++ b/tests/bdd/flex/untagged.feature
@@ -1,0 +1,94 @@
+Feature: Adding untagged objects to a flex database
+
+    Scenario: Import with normal and "untagged" callbacks
+        Given the style file 'test_output_flex_untagged.lua'
+        And the OSM data
+            """
+            n11 v1 dV x1 y1
+            n12 v1 dV x2 y2
+            n13 v1 dV x3 y3
+            n14 v1 dV Tamenity=restaurant x4 y4
+            w20 v1 dV Thighway=primary Nn11,n12
+            w21 v1 dV Nn13,n14
+            r30 v1 dV Mn11@,w20@
+            r31 v1 dV Ttype=route Mw20@
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_nodes contains exactly
+            | node_id | tagged | tags |
+            | 11      | False  | {} |
+            | 12      | False  | {} |
+            | 13      | False  | {} |
+            | 14      | True   | {'amenity': 'restaurant'} |
+
+        Then table osm2pgsql_test_ways contains exactly
+            | way_id | tagged | tags |
+            | 20     | True   | {'highway': 'primary'} |
+            | 21     | False  | {} |
+
+        Then table osm2pgsql_test_relations contains exactly
+            | relation_id | tagged | tags |
+            | 30          | False  | {} |
+            | 31          | True   | {'type': 'route'} |
+
+    Scenario: Import then update with normal and "untagged" callbacks
+        Given the style file 'test_output_flex_untagged.lua'
+        And the OSM data
+            """
+            n11 v1 dV x1 y1
+            n12 v1 dV x2 y2
+            n13 v1 dV x3 y3
+            n14 v1 dV Tamenity=restaurant x4 y4
+            w20 v1 dV Thighway=primary Nn11,n12
+            w21 v1 dV Nn13,n14
+            w22 v1 dV Nn11,n12
+            r30 v1 dV Mn11@,w20@
+            r31 v1 dV Ttype=route Mw20@
+            """
+        When running osm2pgsql flex with parameters
+            | --slim |
+        Then table osm2pgsql_test_nodes contains exactly
+            | node_id | tagged | tags |
+            | 11      | False  | {} |
+            | 12      | False  | {} |
+            | 13      | False  | {} |
+            | 14      | True   | {'amenity': 'restaurant'} |
+
+        Then table osm2pgsql_test_ways contains exactly
+            | way_id | tagged | tags |
+            | 20     | True   | {'highway': 'primary'} |
+            | 21     | False  | {} |
+            | 22     | False  | {} |
+
+        Then table osm2pgsql_test_relations contains exactly
+            | relation_id | tagged | tags |
+            | 30          | False  | {} |
+            | 31          | True   | {'type': 'route'} |
+
+        Given the style file 'test_output_flex_untagged.lua'
+        And the OSM data
+            """
+            n11 v2 dV Tnatural=tree x1 y1
+            n14 v2 dV x4 y4
+            w21 v2 dV Nn14,n13
+            """
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+        Then table osm2pgsql_test_nodes contains exactly
+            | node_id | tagged | tags |
+            | 11      | True   | {'natural': 'tree'} |
+            | 12      | False  | {} |
+            | 13      | False  | {} |
+            | 14      | False  | {} |
+
+        Then table osm2pgsql_test_ways contains exactly
+            | way_id | tagged | tags |
+            | 20     | True   | {'highway': 'primary'} |
+            | 21     | False  | {} |
+            | 22     | False  | {} |
+
+        Then table osm2pgsql_test_relations contains exactly
+            | relation_id | tagged | tags |
+            | 30          | False  | {} |
+            | 31          | True   | {'type': 'route'} |
+

--- a/tests/data/test_output_flex_untagged.lua
+++ b/tests/data/test_output_flex_untagged.lua
@@ -1,0 +1,53 @@
+
+local tables = {}
+
+tables.nodes = osm2pgsql.define_node_table('osm2pgsql_test_nodes', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'tagged', type = 'bool' },
+    { column = 'geom', type = 'point', not_null = true },
+})
+
+tables.ways = osm2pgsql.define_way_table('osm2pgsql_test_ways', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'tagged', type = 'bool' },
+    { column = 'geom', type = 'linestring', not_null = true },
+})
+
+tables.relations = osm2pgsql.define_relation_table('osm2pgsql_test_relations', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'tagged', type = 'bool' },
+    { column = 'geom', type = 'geometry', not_null = true },
+})
+
+local function insert(dtable, object, tagged, geom)
+    tables[dtable]:insert({
+        tags = object.tags,
+        tagged = tagged,
+        geom = geom,
+    })
+end
+
+function osm2pgsql.process_node(object)
+    insert('nodes', object, true, object:as_point())
+end
+
+function osm2pgsql.process_way(object)
+    insert('ways', object, true, object:as_linestring())
+end
+
+function osm2pgsql.process_relation(object)
+    insert('relations', object, true, object:as_geometrycollection())
+end
+
+function osm2pgsql.process_untagged_node(object)
+    insert('nodes', object, false, object:as_point())
+end
+
+function osm2pgsql.process_untagged_way(object)
+    insert('ways', object, false, object:as_linestring())
+end
+
+function osm2pgsql.process_untagged_relation(object)
+    insert('relations', object, false, object:as_geometrycollection())
+end
+


### PR DESCRIPTION
When we introduced the "untagged" callbacks in bc87ea2c8b4ea0bcac09975627e78765fda8927e, we did not call the process_untagged_way/relation callbacks for untagged ways/relations  in stage 1b and 1c, but called the normal process_way/relation callbacks. That's not correct. So this is changed in this commit.

For stage2 processing the answer which callback to call is a bit more complicated: On first glance we should also call the "untagged" function for untagged objects. But if we call the "untagged" function in that case, we would have to implement that function and it would be called for the millions of untagged objects we are not interested in. So it is arguably better to call the normal processing functions here. After all we explicitly requested the processing function to be called with the select_relation_members() call. So we are keeping this behaviour.
