### PR TITLE
Move and fix tests for unique and primary key id indexes

### DIFF
--- a/tests/bdd/flex/lua-table-definitions.feature
+++ b/tests/bdd/flex/lua-table-definitions.feature
@@ -99,40 +99,6 @@ Feature: Table definitions in Lua file
         When running osm2pgsql flex
         Then table foo has 1562 rows
 
-    Scenario: Unique index is okay
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            local t = osm2pgsql.define_table({
-                name = 'foo',
-                ids = { type = 'node', id_column = 'node_id', index = 'unique' },
-                columns = {}
-            })
-
-            function osm2pgsql.process_node(object)
-                t:insert({})
-            end
-            """
-        When running osm2pgsql flex
-        Then table foo has 1562 rows
-
-    Scenario: Primary key is okay
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            local t = osm2pgsql.define_table({
-                name = 'foo',
-                ids = { type = 'node', id_column = 'node_id', index = 'primary_key' },
-                columns = {}
-            })
-
-            function osm2pgsql.process_node(object)
-                t:insert({})
-            end
-            """
-        When running osm2pgsql flex
-        Then table foo has 1562 rows
-
     Scenario: Can not create two tables with the same name
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style

--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -153,6 +153,8 @@ class DBRow:
                 self.data.append(None)
             elif head.lower().startswith('st_astext('):
                 self.data.append(DBValueGeometry(value, props, factory))
+            elif props == 'fullmatch':
+                self.data.append(DBValueRegex(value))
             else:
                 self.data.append(str(value))
 
@@ -231,6 +233,18 @@ class DBValueFloat:
             return False
 
         return math.isclose(self.value, fother, rel_tol=self.precision)
+
+    def __repr__(self):
+        return repr(self.value)
+
+
+class DBValueRegex:
+
+    def __init__(self, value):
+        self.value = str(value)
+
+    def __eq__(self, other):
+        return re.fullmatch(str(other), self.value) is not None
 
     def __repr__(self):
         return repr(self.value)


### PR DESCRIPTION
We already have a bunch of BDD tests for index creation which check that the index exists. The tests for unique and primary key ID index were still in a different file for some reason. This PR moves the tests to the other index tests, adds checks that the indexes are created and fixes the bad 'index' parameter.

Also adds a new syntax for allowing regex comparison.

Fixes #2380.