### PR TITLE
Remove mentioning of verbose help from osm2pgsql man page

### DIFF
--- a/man/osm2pgsql.1
+++ b/man/osm2pgsql.1
@@ -48,7 +48,6 @@ Removes existing data from the database tables!
 .TP
 -h, --help
 Print help.
-Add \f[B]-v, --verbose\f[R] to display more verbose help.
 .TP
 -V, --version
 Print osm2pgsql version.

--- a/man/osm2pgsql.md
+++ b/man/osm2pgsql.md
@@ -46,7 +46,7 @@ mandatory for short options too.
 # HELP/VERSION OPTIONS
 
 -h, \--help
-:   Print help. Add **-v, \--verbose** to display more verbose help.
+:   Print help.
 
 -V, \--version
 :   Print osm2pgsql version.


### PR DESCRIPTION
This has not been working since we switched to the new command line parsing library...