### PR TITLE
Add suffix_t to all classes and enable naming checks in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -106,4 +106,26 @@ CheckOptions:
       value: true
     - key: bugprone-empty-catch.IgnoreCatchWithKeywords
       value: "@todo;@fixme;exception ignored on purpose"
+    - key: readability-identifier-naming.ClassCase
+      value: lower_case
+    - key: readability-identifier-naming.ClassSuffix
+      value: _t
+    - key: readability-identifier-naming.PrivateMemberPrefix
+      value: m_
+    - key: readability-identifier-naming.StructCase
+      value: lower_case
+    - key: readability-identifier-naming.EnumCase
+      value: lower_case
+    - key: readability-identifier-naming.FunctionCase
+      value: lower_case
+    - key: readability-identifier-naming.FunctionIgnoredRegexp
+      value: luaX.*
+    - key: readability-identifier-naming.VariableCase
+      value: lower_case
+    - key: readability-identifier-naming.ConstexprVariableCase
+      value: UPPER_CASE
+    - key: readability-identifier-naming.GlobalConstantCase
+      value: UPPER_CASE
+    - key: readability-identifier-naming.NamespaceCase
+      value: lower_case
 ...

--- a/src/geom-functions.cpp
+++ b/src/geom-functions.cpp
@@ -69,10 +69,10 @@ std::size_t num_geometries(geometry_t const &geom)
 
 namespace {
 
-class geometry_n_visitor
+class geometry_n_visitor_t
 {
 public:
-    geometry_n_visitor(geometry_t *output, std::size_t n)
+    geometry_n_visitor_t(geometry_t *output, std::size_t n)
     : m_output(output), m_n(n)
     {}
 
@@ -97,7 +97,7 @@ private:
     geometry_t *m_output;
     std::size_t m_n;
 
-}; // class geometry_n_visitor
+}; // class geometry_n_visitor_t
 
 } // anonymous namespace
 
@@ -109,7 +109,7 @@ void geometry_n(geometry_t *output, geometry_t const &input, std::size_t n)
         return;
     }
 
-    input.visit(geometry_n_visitor{output, n - 1});
+    input.visit(geometry_n_visitor_t{output, n - 1});
     output->set_srid(input.srid());
 }
 
@@ -130,11 +130,11 @@ void set_to_same_type(geometry_t *output, geometry_t const &input)
     input.visit([&](auto in) { output->set<decltype(in)>(); });
 }
 
-class transform_visitor
+class transform_visitor_t
 {
 public:
-    explicit transform_visitor(geometry_t *output,
-                               reprojection const *reprojection)
+    explicit transform_visitor_t(geometry_t *output,
+                                 reprojection const *reprojection)
     : m_output(output), m_reprojection(reprojection)
     {}
 
@@ -190,7 +190,7 @@ public:
             auto &new_geom = m.add_geometry();
             set_to_same_type(&new_geom, geom);
             new_geom.set_srid(0);
-            geom.visit(transform_visitor{&new_geom, m_reprojection});
+            geom.visit(transform_visitor_t{&new_geom, m_reprojection});
         }
     }
 
@@ -222,7 +222,7 @@ private:
     geometry_t *m_output;
     reprojection const *m_reprojection;
 
-}; // class transform_visitor
+}; // class transform_visitor_t
 
 } // anonymous namespace
 
@@ -233,7 +233,7 @@ void transform(geometry_t *output, geometry_t const &input,
 
     set_to_same_type(output, input);
     output->set_srid(reprojection.target_srs());
-    input.visit(transform_visitor{output, &reprojection});
+    input.visit(transform_visitor_t{output, &reprojection});
 }
 
 geometry_t transform(geometry_t const &input, reprojection const &reprojection)
@@ -251,10 +251,10 @@ namespace {
  * Helper class for iterating over all points except the first one in a point
  * list.
  */
-class without_first
+class without_first_t
 {
 public:
-    explicit without_first(point_list_t const &list) : m_list(&list) {}
+    explicit without_first_t(point_list_t const &list) : m_list(&list) {}
 
     point_list_t::const_iterator begin()
     {
@@ -266,7 +266,7 @@ public:
 
 private:
     point_list_t const *m_list;
-}; // class without_first
+}; // class without_first_t
 
 void split_linestring(linestring_t const &line, double split_at,
                       multilinestring_t *output)
@@ -276,7 +276,7 @@ void split_linestring(linestring_t const &line, double split_at,
     linestring_t *out = &output->add_geometry();
     out->push_back(prev_pt);
 
-    for (auto const &this_pt : without_first(line)) {
+    for (auto const &this_pt : without_first_t(line)) {
         double const delta = distance(prev_pt, this_pt);
 
         // figure out if the addition of this point would take the total
@@ -428,10 +428,10 @@ double length(geometry_t const &geom)
 
 namespace {
 
-class split_visitor
+class split_visitor_t
 {
 public:
-    split_visitor(std::vector<geometry_t> *output, int srid) noexcept
+    split_visitor_t(std::vector<geometry_t> *output, int srid) noexcept
     : m_output(output), m_srid(srid)
     {}
 
@@ -462,7 +462,7 @@ private:
     std::vector<geometry_t> *m_output;
     int m_srid;
 
-}; // class split_visitor
+}; // class split_visitor_t
 
 } // anonymous namespace
 
@@ -471,7 +471,7 @@ std::vector<geometry_t> split_multi(geometry_t &&geom, bool split_multi)
     std::vector<geometry_t> output;
 
     if (split_multi && geom.is_multi()) {
-        visit(split_visitor{&output, geom.srid()}, std::move(geom));
+        visit(split_visitor_t{&output, geom.srid()}, std::move(geom));
     } else if (!geom.is_null()) {
         output.push_back(std::move(geom));
     }

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -151,10 +151,10 @@ void pgsql_parse_json_tags(char const *string, osmium::memory::Buffer *buffer,
 /**
  * Helper class for parsing relation members encoded in JSON.
  */
-class member_list_json_builder
+class member_list_json_builder_t
 {
 public:
-    explicit member_list_json_builder(
+    explicit member_list_json_builder_t(
         osmium::builder::RelationMemberListBuilder *builder)
     : m_builder(builder)
     {}
@@ -246,7 +246,7 @@ private:
         ref,
         role
     } m_next_val = next_val::none;
-}; // class member_list_json_builder
+}; // class member_list_json_builder_t
 
 template <typename T>
 void pgsql_parse_json_members(char const *string,
@@ -257,7 +257,7 @@ void pgsql_parse_json_members(char const *string,
     }
 
     osmium::builder::RelationMemberListBuilder builder{*buffer, obuilder};
-    member_list_json_builder parser{&builder};
+    member_list_json_builder_t parser{&builder};
     nlohmann::json::sax_parse(string, &parser);
 }
 

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -197,13 +197,13 @@ namespace {
  * handles this extra processing by starting a number of threads and doing
  * the processing in them.
  */
-class multithreaded_processor
+class multithreaded_processor_t
 {
 public:
-    multithreaded_processor(connection_params_t const &connection_params,
-                            std::shared_ptr<middle_t> const &mid,
-                            std::shared_ptr<output_t> output,
-                            std::size_t thread_count)
+    multithreaded_processor_t(connection_params_t const &connection_params,
+                              std::shared_ptr<middle_t> const &mid,
+                              std::shared_ptr<output_t> output,
+                              std::size_t thread_count)
     : m_output(std::move(output))
     {
         assert(mid);
@@ -379,8 +379,8 @@ private:
 
 void osmdata_t::process_dependents()
 {
-    multithreaded_processor proc{m_connection_params, m_mid, m_output,
-                                 m_num_procs};
+    multithreaded_processor_t proc{m_connection_params, m_mid, m_output,
+                                   m_num_procs};
 
     // stage 1b processing: process parents of changed objects
     if (!m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty()) {

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -195,10 +195,10 @@ void write_collection(std::string *data, geom::collection_t const &geom,
     }
 }
 
-class make_ewkb_visitor
+class make_ewkb_visitor_t
 {
 public:
-    make_ewkb_visitor(uint32_t srid, bool ensure_multi) noexcept
+    make_ewkb_visitor_t(uint32_t srid, bool ensure_multi) noexcept
     : m_srid(srid), m_ensure_multi(ensure_multi)
     {}
 
@@ -292,7 +292,7 @@ private:
     uint32_t m_srid;
     bool m_ensure_multi;
 
-}; // class make_ewkb_visitor
+}; // class make_ewkb_visitor_t
 
 /**
  * Parser for (E)WKB.
@@ -560,7 +560,7 @@ private:
 
 std::string geom_to_ewkb(geom::geometry_t const &geom, bool ensure_multi)
 {
-    return geom.visit(ewkb::make_ewkb_visitor{
+    return geom.visit(ewkb::make_ewkb_visitor_t{
         static_cast<uint32_t>(geom.srid()), ensure_multi});
 }
 

--- a/tests/test-flex-indexes.cpp
+++ b/tests/test-flex-indexes.cpp
@@ -15,10 +15,10 @@
 
 #include <lua.hpp>
 
-class test_framework
+class test_framework_t
 {
 public:
-    test_framework()
+    test_framework_t()
     : m_lua_state(luaL_newstate(), [](lua_State *state) { lua_close(state); })
     {
         auto &c = database_capabilities_for_testing();
@@ -46,7 +46,7 @@ private:
 
 TEST_CASE("check index with single column", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("geom", "geometry", "");
@@ -69,7 +69,7 @@ TEST_CASE("check index with single column", "[NoDB]")
 
 TEST_CASE("check index with multiple columns", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("a", "int", "");
@@ -91,7 +91,7 @@ TEST_CASE("check index with multiple columns", "[NoDB]")
 
 TEST_CASE("check unique index", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
@@ -113,7 +113,7 @@ TEST_CASE("check unique index", "[NoDB]")
 
 TEST_CASE("check index with tablespace from table", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.set_index_tablespace("foo");
@@ -135,7 +135,7 @@ TEST_CASE("check index with tablespace from table", "[NoDB]")
 
 TEST_CASE("check index with tablespace", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
@@ -157,7 +157,7 @@ TEST_CASE("check index with tablespace", "[NoDB]")
 
 TEST_CASE("check index with expression and where clause", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "text", "");
@@ -179,7 +179,7 @@ TEST_CASE("check index with expression and where clause", "[NoDB]")
 
 TEST_CASE("check index with include", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
@@ -202,7 +202,7 @@ TEST_CASE("check index with include", "[NoDB]")
 
 TEST_CASE("check index with include as array", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
@@ -225,7 +225,7 @@ TEST_CASE("check index with include as array", "[NoDB]")
 
 TEST_CASE("check index with empty include array", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "int", "");
@@ -248,7 +248,7 @@ TEST_CASE("check index with empty include array", "[NoDB]")
 
 TEST_CASE("check multiple indexes", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("a", "int", "");
@@ -271,7 +271,7 @@ TEST_CASE("check multiple indexes", "[NoDB]")
 
 TEST_CASE("check various broken index configs", "[NoDB]")
 {
-    test_framework const tf;
+    test_framework_t const tf;
 
     flex_table_t table{"public", "test_table", 0};
     table.add_column("col", "text", "");

--- a/tests/test-util.cpp
+++ b/tests/test-util.cpp
@@ -44,17 +44,17 @@ TEST_CASE("human readable time durations", "[NoDB]")
 
 TEST_CASE("find_by_name()", "[NoDB]")
 {
-    class test_class
+    class test_class_t
     {
     public:
-        explicit test_class(std::string n) : m_name(std::move(n)) {}
+        explicit test_class_t(std::string n) : m_name(std::move(n)) {}
         std::string name() const noexcept { return m_name; }
 
     private:
         std::string m_name;
     };
 
-    std::vector<test_class> t;
+    std::vector<test_class_t> t;
 
     REQUIRE(util::find_by_name(t, "") == nullptr);
     REQUIRE(util::find_by_name(t, "foo") == nullptr);


### PR DESCRIPTION
Over the last months we have fixed some issues with inconsistent naming. This is the (for the time being) last such change adding `_t` to class name that don't have that already.

And this PR enables checks in clang-tidy to make sure we keep to our naming rules in the future.