### PR TITLE
CI: Treat warnings as errors for MSCV build and for clang-tidy

### DIFF
--- a/.github/actions/clang-tidy/action.yml
+++ b/.github/actions/clang-tidy/action.yml
@@ -5,5 +5,5 @@ runs:
 
     steps:
       - name: Run clang-tidy
-        run: run-clang-tidy-17 -q -p build
+        run: run-clang-tidy-17 -q -p build -warnings-as-errors=\*
         shell: bash

--- a/.github/actions/win-cmake/action.yml
+++ b/.github/actions/win-cmake/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
 
     - name: Configure
-      run: cmake -LA .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTS=ON -DBoost_USE_STATIC_LIBS=ON
+      run: cmake -LA .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTS=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DBoost_USE_STATIC_LIBS=ON
       shell: bash
       working-directory: build
 


### PR DESCRIPTION
For a long time now we have built with `-Werror` in the Linux builds in the CI. Now that we have finally fixed (or worked-around or disabled) the last warnings from MSVC and from clang-tidy we can change the CI to also do the equivalent of `-Werror` for Windows builds and for the clang-tidy build.