### PR TITLE
Revert "Enable more checks in clang-tidy around naming"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -106,26 +106,4 @@ CheckOptions:
       value: true
     - key: bugprone-empty-catch.IgnoreCatchWithKeywords
       value: "@todo;@fixme;exception ignored on purpose"
-    - key: readability-identifier-naming.ClassCase
-      value: lower_case
-    - key: readability-identifier-naming.ClassSuffix
-      value: _t
-    - key: readability-identifier-naming.PrivateMemberPrefix
-      value: m_
-    - key: readability-identifier-naming.StructCase
-      value: lower_case
-    - key: readability-identifier-naming.EnumCase
-      value: lower_case
-    - key: readability-identifier-naming.FunctionCase
-      value: lower_case
-    - key: readability-identifier-naming.FunctionIgnoredRegexp
-      value: luaX.*
-    - key: readability-identifier-naming.VariableCase
-      value: lower_case
-    - key: readability-identifier-naming.ConstexprVariableCase
-      value: UPPER_CASE
-    - key: readability-identifier-naming.GlobalConstantCase
-      value: UPPER_CASE
-    - key: readability-identifier-naming.NamespaceCase
-      value: lower_case
 ...


### PR DESCRIPTION
clang-tidy has been misleading us. For some reason the naming checks haven't reported all errors in the CI. Disable checks again for now.