### PR TITLE
Add support for checking for Multi* geometries in BDD tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
     runs-on: windows-2025
 
     env:
-      OSMURL: https://download.geofabrik.de/europe/monaco-latest.osm.bz2
+      OSMURL: https://download.geofabrik.de/europe/monaco-latest.osm.pbf
 
     steps:
       - uses: actions/checkout@v4
@@ -398,8 +398,9 @@ jobs:
           & $env:PGBIN\psql -d osm -c "CREATE EXTENSION hstore; CREATE EXTENSION postgis;"
         shell: pwsh
       - name: Get test data
-        run: (new-object net.webclient).DownloadFile($env:OSMURL, "testfile.osm.bz2")
+        run: Invoke-WebRequest -Uri $env:OSMURL -OutFile "testfile.osm.pbf"
+        shell: pwsh
       - name: Execute osm2pgsql
-        run: ./osm2pgsql-bin/osm2pgsql --slim -d osm testfile.osm.bz2
+        run: ./osm2pgsql-bin/osm2pgsql --slim -d osm testfile.osm.pbf
         shell: bash
 

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -45,11 +45,11 @@ Feature: Create geometry collections from relations
             | 33     | node   | ST_GeometryCollection | 1                      | ST_Point                               |
 
         And table osm2pgsql_test_collection contains exactly
-            | osm_id | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
-            | 30     | 10, 11, 12, 13, 10               | NULL                             |
-            | 31     | 10, 11, 12, 13, 10               | 14, 15, 16                       |
-            | 32     | 17                               | 14, 15, 16                       |
-            | 33     | 17                               | NULL                             |
+            | osm_id | ST_AsText(geom)                    |
+            | 30     | { 10, 11, 12, 13, 10 }             |
+            | 31     | { 10, 11, 12, 13, 10; 14, 15, 16 } |
+            | 32     | { 17; 14, 15, 16 }                 |
+            | 33     | { 17 }                             |
 
         Examples:
             | param  |
@@ -105,6 +105,6 @@ Feature: Create geometry collections from relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_collection contains exactly
-            | osm_id | name  | ST_NumGeometries(geom) | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
-            | 30     | three | 2                      | 10, 11, 12, 13, 10               | 10, 11, 13                       |
+            | osm_id | name  | ST_AsText(geom)                    |
+            | 30     | three | { 10, 11, 12, 13, 10; 10, 11, 13 } |
 

--- a/tests/bdd/flex/geometry-linestring.feature
+++ b/tests/bdd/flex/geometry-linestring.feature
@@ -32,9 +32,9 @@ Feature: Creating linestring features from way
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_lines contains exactly
-            | way_id | ST_AsText(sgeom) | ST_AsText(ST_GeometryN(mgeom, 1)) | ST_AsText(ST_GeometryN(xgeom, 1)) |
-            | 20     | 1, 2, 3          | 1, 2, 3                           | 1, 2, 3                           |
-            | 21     | 4, 5             | 4, 5                              | 4, 5                              |
+            | way_id | ST_AsText(sgeom) | ST_AsText(mgeom) | ST_AsText(xgeom) |
+            | 20     | 1, 2, 3          | [ 1, 2, 3 ]      | [ 1, 2, 3 ]      |
+            | 21     | 4, 5             | [ 4, 5 ]         | [ 4, 5 ]         |
 
     Scenario:
         Given the grid

--- a/tests/bdd/flex/geometry-multilinestring.feature
+++ b/tests/bdd/flex/geometry-multilinestring.feature
@@ -41,11 +41,11 @@ Feature: Creating (multi)linestring features from way and relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_lines contains exactly
-            | osm_type | osm_id | ST_GeometryType(geom) | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
-            | W        | 20     | ST_LineString         | 1, 2, 3                          | NULL                             |
-            | W        | 21     | ST_LineString         | 4, 5, 6                          | NULL                             |
-            | R        | 30     | ST_LineString         | 1, 2, 3                          | NULL                             |
-            | R        | 31     | ST_MultiLineString    | 1, 2, 3                          | 4, 5, 6                          |
+            | osm_type | osm_id | ST_AsText(geom)      |
+            | W        | 20     | 1, 2, 3              |
+            | W        | 21     | 4, 5, 6              |
+            | R        | 30     | 1, 2, 3              |
+            | R        | 31     | [ 1, 2, 3; 4, 5, 6 ] |
 
     Scenario:
         Given the grid
@@ -77,7 +77,7 @@ Feature: Creating (multi)linestring features from way and relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_roads contains exactly
-            | relation_id | ST_GeometryType(geom) | ST_GeometryType(merged) | ST_AsText(ST_GeometryN(merged, 1)) | ST_AsText(ST_GeometryN(merged, 2)) |
-            | 30          | ST_MultiLineString    | ST_MultiLineString      | 1, 2, 3                            | NULL                               |
-            | 31          | ST_MultiLineString    | ST_MultiLineString      | 1, 2                               | 3, 4                               |
+            | relation_id | ST_GeometryType(geom) |  ST_AsText(merged) |
+            | 30          | ST_MultiLineString    |  [ 1, 2, 3 ]       |
+            | 31          | ST_MultiLineString    |  [ 1, 2; 3, 4 ]    |
 

--- a/tests/bdd/flex/geometry-multipoint.feature
+++ b/tests/bdd/flex/geometry-multipoint.feature
@@ -43,9 +43,9 @@ Feature: Creating (multi)point features from nodes and relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_points contains exactly
-            | osm_type | osm_id | ST_GeometryType(geom) | ST_NumGeometries(geom) | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
-            | N        | 1      | ST_Point              | 1                      | 1                                | NULL                             |
-            | N        | 5      | ST_Point              | 1                      | 5                                | NULL                             |
-            | R        | 30     | ST_Point              | 1                      | 1                                | NULL                             |
-            | R        | 31     | ST_MultiPoint         | 2                      | 5                                | 1                                |
+            | osm_type | osm_id | ST_AsText(geom) |
+            | N        | 1      | 1               |
+            | N        | 5      | 5               |
+            | R        | 30     | 1               |
+            | R        | 31     | [ 5; 1 ]        |
 


### PR DESCRIPTION
This adds new syntax options for expressing a geometry in the BDD tests:

```
[ <geometry>; ... ]
```

will mean that you expect a MULTI* geometry. The geometries need to be of the same type, obviously.

```
{ <geometry>; ... }
```

means to expect a GEOMETRYCOLLECTION. The inner geometries can be arbitrary simple types. No multi geometries, no collections.

This makes the tests involving multi geometries and collections considerably simpler. It incidentally also works around a [bug with ST_GeometryN in PostGIS 3.6.0](https://trac.osgeo.org/postgis/ticket/5987).

NB: also changes the CI to using pbf for tests as xml files are not offered anymore by Geofabrik.