### PR TITLE
Install osm2pgsql-expire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ include(GNUInstallDirs)
 
 if (ENABLE_INSTALL)
     install(TARGETS osm2pgsql DESTINATION bin)
+    install(TARGETS osm2pgsql-expire DESTINATION bin)
     install(FILES default.style empty.style DESTINATION share/osm2pgsql)
     install(PROGRAMS scripts/osm2pgsql-replication DESTINATION bin)
     if (BUILD_GEN)


### PR DESCRIPTION
Add osm2pgsql-expire to the installed binaries. If we decide to keep it, then it will go out of the experimental state by the next version and need to be installed. If we don't keep it, then we just can get rid of everything related to it in the CMakeFile.

Fixes #2419.