### PR TITLE
Bdd select step

### DIFF
--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -154,10 +154,3 @@ def test_db(context, **kwargs):
 def working_directory(context, **kwargs):
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
-
-
-def before_tag(context, tag):
-    if tag == 'needs-pg-index-includes':
-        if context.config.userdata['PG_VERSION'] < 110000:
-            context.scenario.skip("No index includes in PostgreSQL < 11")
-

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -122,6 +122,7 @@ def before_scenario(context, scenario):
     context.geometry_factory = GeometryFactory()
     context.osm2pgsql_replication.ReplicationServer = ReplicationServerMock()
     context.urlrequest_responses = {}
+    context.sql_statements = {}
 
     def _mock_urlopen(request):
         if not request.full_url in context.urlrequest_responses:

--- a/tests/bdd/flex/delete-callbacks.feature
+++ b/tests/bdd/flex/delete-callbacks.feature
@@ -27,21 +27,29 @@ Feature: Test for delete callbacks
 
         Given the input file '008-ch.osc.gz'
 
+        Given the SQL statement grouped_counts
+            """
+            SELECT osm_type,
+                   count(*),
+                   sum(extra) AS sum_extra,
+                   sum(osm_id) AS sum_osm_id
+            FROM change
+            GROUP BY osm_type
+            """
+
     Scenario: Delete callbacks are called
         When running osm2pgsql flex with parameters
             | --slim | -a |
-
-        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
-            | osm_type | count | sum |
-            | N        | 16773 | 16779 |
-            | W        | 4     | 9 |
-            | R        | 1     | 3 |
+        Then statement grouped_counts returns exactly
+            | osm_type | count | sum_extra |
+            | N        | 16773 | 16779     |
+            | W        | 4     | 9         |
+            | R        | 1     | 3         |
 
         When running osm2pgsql flex with parameters
             | --slim | -a |
-
-        Then SELECT osm_type, count(*), sum(osm_id) FROM change GROUP BY osm_type
-            | osm_type | count | sum |
+        Then statement grouped_counts returns exactly
+            | osm_type | count | sum_osm_id |
             | N        | 16773 | 37856781001834 |
             | W        | 4     | 350933407 |
             | R        | 1     | 2871571 |
@@ -72,8 +80,8 @@ Feature: Test for delete callbacks
             """
         When running osm2pgsql flex with parameters
             | --slim | -a |
-        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
-            | osm_type | count | sum |
+        Then statement grouped_counts returns exactly
+            | osm_type | count | sum_extra |
             | N        | 16773 | 16773 |
             | W        | 4     | 4 |
             | R        | 1     | 1 |
@@ -105,8 +113,8 @@ Feature: Test for delete callbacks
             """
         When running osm2pgsql flex with parameters
             | --slim | -a |
-        Then SELECT osm_type, count(*), sum(extra) FROM change GROUP BY osm_type
-            | osm_type | count | sum |
+        Then statement grouped_counts returns exactly
+            | osm_type | count | sum_extra |
             | N        | 16773 | 16773|
             | W        | 4     | 4|
             | R        | 1     | 1|

--- a/tests/bdd/flex/lua-index-definitions.feature
+++ b/tests/bdd/flex/lua-index-definitions.feature
@@ -255,7 +255,6 @@ Feature: Index definitions in Lua file
             | indexdef@substr |
             | USING btree (lower(name)) |
 
-    @needs-pg-index-includes
     Scenario: Include field must be a string or array
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
@@ -279,7 +278,6 @@ Feature: Index definitions in Lua file
             The 'include' field in an index definition must contain a string or an array.
             """
 
-    @needs-pg-index-includes
     Scenario: Include field must contain a valid column
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
@@ -303,7 +301,6 @@ Feature: Index definitions in Lua file
             Unknown column 'foo' in table 'mytable'.
             """
 
-    @needs-pg-index-includes
     Scenario: Include field works with string
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
@@ -326,7 +323,6 @@ Feature: Index definitions in Lua file
             | indexdef@substr |
             | USING btree (name) INCLUDE (tags) |
 
-    @needs-pg-index-includes
     Scenario: Include field works with array
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style

--- a/tests/bdd/regression/multipolygon.feature
+++ b/tests/bdd/regression/multipolygon.feature
@@ -3,6 +3,16 @@ Feature: Import and update of multipolygon areas
     Background:
         Given the input file 'test_multipolygon.osm'
 
+        Given the SQL statement grouped_polygons
+            """
+            SELECT osm_id,
+                   count(*) AS count,
+                   round(sum(ST_Area(way))) AS area,
+                   round(sum(way_area::numeric)) AS way_area
+            FROM planet_osm_polygon
+            GROUP BY osm_id
+            """
+
     Scenario Outline: Import and update slim
         Given <lua> lua tagtransform
         When running osm2pgsql pgsql with parameters
@@ -35,7 +45,7 @@ Feature: Import and update of multipolygon areas
             | osm_id | landuse     | name       | ST_NumInteriorRing(way) |
             | -3     | residential | Name_rel11 | 2                       |
 
-        Then SELECT osm_id, round(sum(ST_Area(way))), round(sum(way_area::numeric)) FROM planet_osm_polygon GROUP BY osm_id
+        Then statement grouped_polygons returns
             | osm_id | area  | way_area |
             | -13    | 17581 | 17581    |
             | -7     | 16169 | 16169    |
@@ -43,7 +53,7 @@ Feature: Import and update of multipolygon areas
             | -39    | 10377 | 10378    |
             | -40    | 12397 | 12397    |
 
-        Then SELECT osm_id, count(*) FROM planet_osm_polygon GROUP BY osm_id
+        Then statement grouped_polygons returns
             | osm_id | count |
             | -25    | 1     |
             | 113    | 1     |
@@ -63,7 +73,15 @@ Feature: Import and update of multipolygon areas
             | osm_id | "natural" |
             | -33    | water     |
 
-        Then SELECT osm_id, CASE WHEN '<param1>' = '-G' THEN min(ST_NumGeometries(way)) ELSE count(*) END FROM planet_osm_polygon GROUP BY osm_id
+        Given the SQL statement geometries_polygon
+            """
+            SELECT osm_id,
+                   CASE WHEN '<param1>' = '-G' THEN min(ST_NumGeometries(way))
+                   ELSE count(*) END AS count
+            FROM planet_osm_polygon
+            GROUP BY osm_id
+            """
+        Then statement geometries_polygon returns
            | osm_id | count |
            | -13    | 2     |
            | -7     | 2     |
@@ -99,7 +117,7 @@ Feature: Import and update of multipolygon areas
             | osm_id | landuse     | name       | ST_NumInteriorRing(way) |
             | -3     | residential | Name_rel11 | 2                       |
 
-        Then SELECT osm_id, round(sum(ST_Area(way))), round(sum(way_area::numeric)) FROM planet_osm_polygon GROUP BY osm_id
+        Then statement grouped_polygons returns
             | osm_id | area  | way_area |
             | -13    | 17581 | 17581    |
             | -7     | 16169 | 16169    |
@@ -107,7 +125,7 @@ Feature: Import and update of multipolygon areas
             | -39    | 10377 | 10378    |
             | -40    | 12397 | 12397    |
 
-        Then SELECT osm_id, count(*) FROM planet_osm_polygon GROUP BY osm_id
+        Then statement grouped_polygons returns
             | osm_id | count |
             | 113    | 1     |
             | 118    | 1     |

--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -98,9 +98,12 @@ def db_define_sql_statement(context, sql):
 
 @then("statement (?P<stmt>.+) returns(?P<exact> exactly)?")
 def db_check_sql_statement(context, stmt, exact):
+    assert stmt in context.sql_statements
+    rows = sql.SQL(', '.join(h.rsplit('@')[0] for h in context.table.headings))
+
     with context.db.cursor() as cur:
-        assert stmt in context.sql_statements
-        cur.execute(context.sql_statements[stmt])
+        cur.execute(sql.SQL("SELECT {} FROM ({}) _sql_statement")
+                       .format(rows, sql.SQL(context.sql_statements[stmt])))
 
         actuals = list(DBRow(r, context.table.headings, context.geometry_factory) for r in cur)
 

--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -92,18 +92,29 @@ def db_check_table_absence(context, table):
         assert not row in actuals, f"Row unexpectedly found: {row}. Full content:\n{actuals}"
 
 
-@then("(?P<query>SELECT .*)")
-def db_check_sql_statement(context, query):
+@given("the SQL statement (?P<sql>.+)")
+def db_define_sql_statement(context, sql):
+    context.sql_statements[sql] = context.text
+
+@then("statement (?P<stmt>.+) returns(?P<exact> exactly)?")
+def db_check_sql_statement(context, stmt, exact):
     with context.db.cursor() as cur:
-        cur.execute(query)
+        assert stmt in context.sql_statements
+        cur.execute(context.sql_statements[stmt])
 
         actuals = list(DBRow(r, context.table.headings, context.geometry_factory) for r in cur)
 
     linenr = 1
     for row in context.table.rows:
-        assert any(r == row for r in actuals),\
-               f"{linenr}. entry not found in table. Full content:\n{actuals}"
+        try:
+            actuals.remove(row)
+        except ValueError:
+            assert False,\
+                   f"{linenr}. entry not found in result. Full response:\n{actuals}"
         linenr += 1
+
+    assert not exact or not actuals,\
+           f"Unexpected lines in result:\n{actuals}"
 
 
 ### Helper functions and classes
@@ -152,6 +163,8 @@ class DBRow:
                 self.data.append(DBValueGeometry(value, props, factory))
             elif props == 'fullmatch':
                 self.data.append(DBValueRegex(value))
+            elif props == 'substr':
+                self.data.append(DBValueSubString(value))
             else:
                 self.data.append(str(value))
 
@@ -307,6 +320,18 @@ class DBValueRegex:
 
     def __eq__(self, other):
         return re.fullmatch(str(other), self.value) is not None
+
+    def __repr__(self):
+        return repr(self.value)
+
+
+class DBValueSubString:
+
+    def __init__(self, value):
+        self.value = str(value)
+
+    def __eq__(self, other):
+        return str(other) in self.value
 
     def __repr__(self):
         return repr(self.value)


### PR DESCRIPTION
BDD was offering a catch-all check step which simply consisted of a SELECT statement. This PR splits this into a SELECT statement definition:

```
Given the SQL statement foobar
    """
    SELECT foo FROM bar
    """
```

and a statement execution:

```
Then statement foobar returns
    | foo |
    | 0   |
```

This has several advantages:

* SQL statements can now go over multiple lines, making complex ones indefinitely more readable
* execution can now include a `return exactly` like for the table check to catch negative expectations

But most importantly: statements can be reused. That means you can basically define arbitrary check functions for your database content by defining an SQL statement in the Background section of your feature file and then use them in all the scenarios. See the index creation tests for a practical use-case for that.

Other changes sneaked into this PR:

* Remove the @needs-pg-index-includes tag. This was only needed for PG versions 10 and below which we don't support anymore.
* Add a 'substr' checker. This checks if the expected value is contained in the response. This may sometimes more useful than the complex regex checker as it avoids having to quote special regex expressions.