### PR TITLE
Fix presence check for replication script in style tester

### DIFF
--- a/scripts/osm2pgsql-test-style
+++ b/scripts/osm2pgsql-test-style
@@ -95,14 +95,18 @@ class ReplicationServerMock:
 
 
 # Replication module is optional
-_repfl_spec = importlib.util.spec_from_loader(
-    'osm2pgsql_replication',
-    SourceFileLoader('osm2pgsql_replication',
-                     str(Path(__file__, '..', 'osm2pgsql-replication').resolve())))
+_replication_path = Path(__file__, '..', 'osm2pgsql-replication').resolve()
 
-if _repfl_spec:
+if _replication_path.is_file():
+    _repfl_spec = importlib.util.spec_from_loader(
+        'osm2pgsql_replication',
+        SourceFileLoader('osm2pgsql_replication', str(_replication_path)))
+
     osm2pgsql_replication = importlib.util.module_from_spec(_repfl_spec)
-    _repfl_spec.loader.exec_module(osm2pgsql_replication)
+    try:
+        _repfl_spec.loader.exec_module(osm2pgsql_replication)
+    except Exception as e:
+        raise RuntimeError(f"osm2pgsql_replication script found but not readable.")
 
     from osmium.replication.server import OsmosisState
 else:


### PR DESCRIPTION
The spec_from_loader() function does not check for validity of the file. So simply check for presence of the file. Also adds a little try-except around the module execution to print an additional message pointing towards the replication script if loading of the module goes wrong.

Fixes #2464.