### PR TITLE
Use spheroid instead of sphere for spherical_area()

### DIFF
--- a/src/geom-functions.cpp
+++ b/src/geom-functions.cpp
@@ -369,16 +369,14 @@ namespace {
 
 double spherical_area(polygon_t const &geom)
 {
-    boost::geometry::strategy::area::spherical<> const spherical_earth{
-        6371008.8};
-
     using sph_point = boost::geometry::model::point<
-        double, 2,
-        boost::geometry::cs::spherical_equatorial<boost::geometry::degree>>;
+        double, 2, boost::geometry::cs::geographic<boost::geometry::degree>>;
 
     boost::geometry::model::polygon<sph_point> sph_geom;
     boost::geometry::convert(geom, sph_geom);
-    return boost::geometry::area(sph_geom, spherical_earth);
+    return boost::geometry::area(sph_geom,
+                                 boost::geometry::strategy::area::geographic<
+                                     boost::geometry::strategy::vincenty>{});
 }
 
 } // anonymous namespace

--- a/tests/test-geom-linestrings.cpp
+++ b/tests/test-geom-linestrings.cpp
@@ -55,6 +55,7 @@ TEST_CASE("line geometry", "[NoDB]")
     REQUIRE(dimension(geom) == 1);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(1.41421));
     REQUIRE(geometry_type(geom) == "LINESTRING");
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{1.5, 1.5}});
@@ -87,6 +88,7 @@ TEST_CASE("create_linestring from OSM data", "[NoDB]")
     REQUIRE(dimension(geom) == 1);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(1.41421));
     REQUIRE(geom.get<geom::linestring_t>() ==
             geom::linestring_t{{1, 1}, {2, 2}});

--- a/tests/test-geom-multilinestrings.cpp
+++ b/tests/test-geom-multilinestrings.cpp
@@ -35,6 +35,7 @@ TEST_CASE("create_multilinestring with single line", "[NoDB]")
     REQUIRE(dimension(geom) == 1);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(1.0));
     auto const &ml = geom.get<geom::multilinestring_t>();
     REQUIRE(ml.num_geometries() == 1);
@@ -60,6 +61,7 @@ TEST_CASE("create_multilinestring with single line and no force_multi",
     REQUIRE(geometry_type(geom) == "LINESTRING");
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(1.0));
     auto const &l = geom.get<geom::linestring_t>();
     REQUIRE(l.num_geometries() == 1);
@@ -93,6 +95,7 @@ TEST_CASE(
     REQUIRE(geometry_type(geom) == "LINESTRING");
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(1.0));
     auto const &l = geom.get<geom::linestring_t>();
     REQUIRE(l.num_geometries() == 1);

--- a/tests/test-geom-multipoints.cpp
+++ b/tests/test-geom-multipoints.cpp
@@ -32,6 +32,7 @@ TEST_CASE("multipoint_t with a single point", "[NoDB]")
     REQUIRE(dimension(geom) == 0);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(reverse(geom) == geom);
     REQUIRE(centroid(geom) == geom::geometry_t{point});
@@ -55,6 +56,7 @@ TEST_CASE("multipoint_t with several points", "[NoDB]")
     REQUIRE(geometry_type(geom) == "MULTIPOINT");
     REQUIRE(num_geometries(geom) == 3);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(reverse(geom) == geom);
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{2, 1}});
@@ -92,6 +94,7 @@ TEST_CASE("create_multipoint from OSM data", "[NoDB]")
     REQUIRE(c[3] == geom::point_t{3, 1});
 
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{2, 1}});
 }
@@ -118,6 +121,7 @@ TEST_CASE("create_multipoint from OSM data with only a single point", "[NoDB]")
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(geom.get<geom::point_t>() == geom::point_t{1, 0});
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{1, 0}});
 }

--- a/tests/test-geom-multipolygons.cpp
+++ b/tests/test-geom-multipolygons.cpp
@@ -29,7 +29,7 @@ TEST_CASE("multipolygon geometry with single outer, no inner", "[NoDB]")
     REQUIRE(dimension(geom) == 2);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(1.0));
-    REQUIRE(spherical_area(geom) == Approx(12364031798.5));
+    REQUIRE(spherical_area(geom) == Approx(12308778361.469454).epsilon(0.00001));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{0.5, 0.5}});
     REQUIRE(geometry_n(geom, 1) ==
@@ -59,7 +59,7 @@ TEST_CASE("multipolygon geometry with two polygons", "[NoDB]")
     REQUIRE(dimension(geom) == 2);
     REQUIRE(num_geometries(geom) == 2);
     REQUIRE(area(geom) == Approx(9.0));
-    REQUIRE(spherical_area(geom) == Approx(111106540105.7));
+    REQUIRE(spherical_area(geom) == Approx(110615268622.783).epsilon(0.00001));
     REQUIRE(length(geom) == Approx(0.0));
 }
 

--- a/tests/test-geom-null.cpp
+++ b/tests/test-geom-null.cpp
@@ -20,7 +20,8 @@ TEST_CASE("null geometry", "[NoDB]")
 
     REQUIRE(dimension(geom) == 0);
     REQUIRE(num_geometries(geom) == 0);
-    REQUIRE(area(geom) == 0.0);
+    REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(geometry_type(geom) == "NULL");
     REQUIRE(centroid(geom).is_null());

--- a/tests/test-geom-points.cpp
+++ b/tests/test-geom-points.cpp
@@ -68,6 +68,7 @@ TEST_CASE("create_point from OSM data", "[NoDB]")
     REQUIRE(dimension(geom) == 0);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
+    REQUIRE(spherical_area(geom) == Approx(0.0));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{1.1, 2.2}});
     REQUIRE(geometry_n(geom, 1) == geom);

--- a/tests/test-geom-polygons.cpp
+++ b/tests/test-geom-polygons.cpp
@@ -25,7 +25,7 @@ TEST_CASE("polygon geometry without inner", "[NoDB]")
     REQUIRE(dimension(geom) == 2);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(1.0));
-    REQUIRE(spherical_area(geom) == Approx(12364031798.5));
+    REQUIRE(spherical_area(geom) == Approx(12308778361.469454).epsilon(0.00001));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(geometry_type(geom) == "POLYGON");
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{0.5, 0.5}});
@@ -41,7 +41,7 @@ TEST_CASE("polygon geometry without inner (reverse)", "[NoDB]")
     REQUIRE(dimension(geom) == 2);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(1.0));
-    REQUIRE(spherical_area(geom) == Approx(12364031798.5));
+    REQUIRE(spherical_area(geom) == Approx(12308778361.469454).epsilon(0.00001));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(geometry_type(geom) == "POLYGON");
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{0.5, 0.5}});
@@ -65,7 +65,7 @@ TEST_CASE("geom::polygon_t", "[NoDB]")
     REQUIRE(dimension(geom) == 2);
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(8.0));
-    REQUIRE(spherical_area(geom) == Approx(98893356298.4));
+    REQUIRE(spherical_area(geom) == Approx(98452667625.52686).epsilon(0.00001));
     REQUIRE(length(geom) == Approx(0.0));
     REQUIRE(geometry_type(geom) == "POLYGON");
     REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{1.5, 1.5}});


### PR DESCRIPTION
Use spheroid instead of sphere for spherical_area() calculation. This might be a bit more expensive to calculate but is nearer to the default that PostGIS ST_Area returns when called with a geography and no parameter. The old behaviour was using the use_spheroid = false version of ST_Area.

See https://postgis.net/docs/manual-3.5/ST_Area.html