### PR TITLE
Set minimum supported PostgreSQL version to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
 
-  ubuntu22-pg11-gcc10-jit:
+  ubuntu22-pg12-gcc10-jit:
     runs-on: ubuntu-22.04
 
     env:
@@ -12,7 +12,7 @@ jobs:
       CXX: g++-10
       LUA_VERSION: 5.3
       LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 11
+      POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 3
       BUILD_TYPE: Release
       PSYCOPG: 2
@@ -23,7 +23,7 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg11-clang13-jit:
+  ubuntu22-pg12-clang13-jit:
     runs-on: ubuntu-22.04
 
     env:
@@ -31,7 +31,7 @@ jobs:
       CXX: clang++-13
       LUA_VERSION: 5.3
       LUAJIT_OPTION: ON
-      POSTGRESQL_VERSION: 11
+      POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 3
       BUILD_TYPE: Release
       PSYCOPG: 2
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/linux-cmake
       - uses: ./.github/actions/build-and-test
 
-  ubuntu22-pg11-gcc10:
+  ubuntu22-pg12-gcc10:
     runs-on: ubuntu-22.04
 
     env:
@@ -50,7 +50,7 @@ jobs:
       CXX: g++-10
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 11
+      POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 2
@@ -62,7 +62,7 @@ jobs:
       - uses: ./.github/actions/build-and-test
 
 
-  ubuntu22-pg11-clang13:
+  ubuntu22-pg12-clang13:
     runs-on: ubuntu-22.04
 
     env:
@@ -70,7 +70,7 @@ jobs:
       CXX: clang++-13
       LUA_VERSION: 5.3
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 11
+      POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
       PSYCOPG: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,10 +68,10 @@ if (NOT WIN32 AND NOT APPLE)
     set(PostgreSQL_TYPE_INCLUDE_DIR /usr/include)
 endif()
 
-set(MINIMUM_POSTGRESQL_SERVER_VERSION "11")
-set(MINIMUM_POSTGRESQL_SERVER_VERSION_NUM "110000")
+set(MINIMUM_POSTGRESQL_SERVER_VERSION "12")
+set(MINIMUM_POSTGRESQL_SERVER_VERSION_NUM "120000")
 
-set(PostgreSQL_ADDITIONAL_VERSIONS "19" "18" "17" "16" "15" "14" "13" "12" "11")
+set(PostgreSQL_ADDITIONAL_VERSIONS "19" "18" "17" "16" "15" "14" "13" "12")
 
 #############################################################
 # Version

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ option to `ON`) but make sure you are using a compatible version:
 * [protozero](https://github.com/mapbox/protozero) (>= 1.6.3)
 
 It also requires access to a database server running
-[PostgreSQL](https://www.postgresql.org/) (version 11+ works, 13+ strongly
+[PostgreSQL](https://www.postgresql.org/) (version 12+ works, 14+ strongly
 recommended) and [PostGIS](https://www.postgis.net/) (version 3.0+).
 
 Make sure you have installed the development packages for the libraries


### PR DESCRIPTION
There is a change somewhere either between pg 11 and 12 or with the associated PostGIS version used where float resuls have more precision in the new version which makes our tests fail on 11.

Version 11 is out of support upstream anyways.