### PR TITLE
Add function to compare geometries for equality from Lua

### DIFF
--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -39,6 +39,16 @@ geom::geometry_t *unpack_geometry(lua_State *lua_state, int n) noexcept
 
 namespace {
 
+int geom_equals(lua_State *lua_state)
+{
+    auto const *const geometry1 = unpack_geometry(lua_state, 1);
+    auto const *const geometry2 = unpack_geometry(lua_state, 2);
+
+    lua_pushboolean(lua_state, *geometry1 == *geometry2);
+
+    return 1;
+}
+
 /**
  * This function is called by Lua garbage collection when a geometry object
  * needs cleaning up. It calls the destructor of the C++ object. After that
@@ -335,7 +345,8 @@ void init_geometry_class(lua_State *lua_state)
 {
     luaX_set_up_metatable(
         lua_state, "Geometry", OSM2PGSQL_GEOMETRY_CLASS,
-        {{"__gc", geom_gc},
+        {{"__eq", geom_equals},
+         {"__gc", geom_gc},
          {"__len", geom_num_geometries},
          {"__tostring", geom_tostring},
          {"area", geom_area},

--- a/tests/bdd/flex/geometry-linestring.feature
+++ b/tests/bdd/flex/geometry-linestring.feature
@@ -72,3 +72,37 @@ Feature: Creating linestring features from way
             Geometry data for geometry column 'geom' has the wrong type (LINESTRING).
             """
 
+    Scenario:
+        Given the grid
+            | 1 | 2 |
+        And the OSM data
+            """
+            w20 Thighway=motorway Nn1,n1,n2
+            """
+        And the lua style
+            """
+            local points = osm2pgsql.define_way_table('osm2pgsql_test', {
+                { column = 'geom', type = 'point', projection = 4326 },
+                { column = 'dupl', type = 'boolean' },
+            })
+
+            function osm2pgsql.process_way(object)
+                if #object.nodes > 1 then
+                    local prev = object:as_point(1)
+                    points:insert({ geom = prev, dupl = false })
+                    for n = 2, #object.nodes do
+                        local geom = object:as_point(n)
+                        points:insert({ geom = geom, dupl = (prev == geom) })
+                    end
+                end
+            end
+
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test contains exactly
+            | way_id | geom!geo | dupl  |
+            | 20     | 1        | False |
+            | 20     | 1        | True  |
+            | 20     | 2        | False |
+


### PR DESCRIPTION
This can, for instance, be used to check whether there are consecutive nodes with the same location in a way as seen in the test.