### PR TITLE
Throw errors for some command line options values/combinations

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -137,31 +137,31 @@ void check_options_non_slim(CLI::App const &app)
 
     for (auto const &opt : slim_options) {
         if (app.count(opt) > 0) {
-            log_warn("Ignoring option {}. Can only be used in --slim mode.",
-                     app.get_option(opt)->get_name(false, true));
+            throw fmt_error("Option {} can only be used in --slim mode.",
+                            app.get_option(opt)->get_name(false, true));
         }
     }
 }
 
 void check_options_output_flex(CLI::App const &app)
 {
-    auto const ignored_options = app.get_options([](CLI::Option const *option) {
+    auto const bad_options = app.get_options([](CLI::Option const *option) {
         return option->get_group() == "Pgsql output options" ||
                option->get_name() == "--tablespace-main-data" ||
                option->get_name() == "--tablespace-main-index";
     });
 
-    for (auto const *opt : ignored_options) {
+    for (auto const *opt : bad_options) {
         if (opt->count()) {
-            log_warn("Ignoring option {} for 'flex' output",
-                     opt->get_name(false, true));
+            throw fmt_error("Option {} does not work with 'flex' output",
+                            opt->get_name(false, true));
         }
     }
 }
 
 void check_options_output_null(CLI::App const &app)
 {
-    auto const ignored_options = app.get_options([](CLI::Option const *option) {
+    auto const bad_options = app.get_options([](CLI::Option const *option) {
         return option->get_group() == "Pgsql output options" ||
                option->get_group() == "Expire options" ||
                option->get_name() == "--style" ||
@@ -169,10 +169,10 @@ void check_options_output_null(CLI::App const &app)
                option->get_name() == "--number-processes";
     });
 
-    for (auto const *opt : ignored_options) {
+    for (auto const *opt : bad_options) {
         if (opt->count()) {
-            log_warn("Ignoring option {} for 'null' output",
-                     opt->get_name(false, true));
+            throw fmt_error("Option {} does not work with 'null' output",
+                            opt->get_name(false, true));
         }
     }
 }
@@ -208,8 +208,7 @@ void check_options(options_t *options)
     }
 
     if (options->cache < 0) {
-        options->cache = 0;
-        log_warn("RAM cache cannot be negative. Using 0 instead.");
+        throw std::runtime_error{"RAM cache cannot be negative."};
     }
 
     if (options->cache == 0) {
@@ -244,9 +243,9 @@ void check_options_expire(options_t *options)
 
     if (options->expire_tiles_zoom != 0 &&
         options->projection->target_srs() != PROJ_SPHERE_MERC) {
-        log_warn("Expire has been enabled (with -e or --expire-tiles) but "
-                 "target SRS is not Mercator (EPSG:3857). Expire disabled!");
-        options->expire_tiles_zoom = 0;
+        throw std::runtime_error{
+            "Expire has been enabled (with -e or --expire-tiles) but target "
+            "SRS is not Mercator (EPSG:3857)"};
     }
 }
 


### PR DESCRIPTION
Instead of just printing warnings.

Warnings are in since at least 2.0.0 released in September 2024.