### PR TITLE
Permit any data type for group_by column

### DIFF
--- a/src/gen/gen-tile-raster.cpp
+++ b/src/gen/gen-tile-raster.cpp
@@ -149,7 +149,7 @@ SELECT "{geom_column}", "{group_by_column}"
 )";
         dbprepare("insert_geoms", R"(
 INSERT INTO {dest} ("{geom_column}", x, y, "{group_by_column}")
- VALUES ({geom_sql}, $2::int, $3::int, $4::text)
+ VALUES ({geom_sql}, $2::int, $3::int, $4)
 )");
     } else {
         prepare = R"(


### PR DESCRIPTION
Drop casting the `group_by_column` to text.

In my use case, I create a WMS version of OSM Carto. I have a table `water_polygons` with water bodies. It has a boolean field `int_intermittent` which is derived from OSM tags `intermittent=*` and `seasonal=*` (what OSM Carto does using SQL will be done by Lua in my use case).

I want to create a generalised set of polygons for lower zoom levels. The generalised set of polygons should still distinguish between permanent and intermittent water bodies. It is unnecessary to store the boolean property as text.